### PR TITLE
Build macOS wheels with GitHub Actions

### DIFF
--- a/.github/workflows/wheel-macos.yml
+++ b/.github/workflows/wheel-macos.yml
@@ -1,0 +1,84 @@
+name: Build macOS wheels
+# May be combined with Windows action later
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: macos-latest
+
+    strategy:
+      fail-fast: true
+      matrix:
+        python-version: [3.8]
+        python-arch: [x64]
+        boost-version: [1_72_0]
+        include:
+          - python-version: 3.8
+            numpy-version: 1.17.3
+
+    name: macOS Python ${{ matrix.python-version }} ${{ matrix.python-arch }}
+
+    steps:
+
+      - uses: actions/checkout@v2
+
+      - name: Checkout submodules
+        run: |
+          git submodule sync --recursive
+          git submodule update --init --force --recursive --depth=1
+
+      - uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: ${{ matrix.python-arch }}
+
+      - name: Install tools
+        run: |
+          brew install swig
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade setuptools wheel
+          python -m pip install numpy==${{ matrix.numpy-version }}
+
+      - name: Build Boost
+        run: |
+          BOOST_VER=${{ matrix.boost-version }}
+          BOOST_TGZ=boost_$BOOST_VER.tar.gz
+          curl -LO https://dl.bintray.com/boostorg/release/${BOOST_VER//_/.}/source/$BOOST_TGZ
+          tar xzf $BOOST_TGZ
+          cd boost_$BOOST_VER
+          ./bootstrap.sh
+          ./b2 --with-system --with-thread --with-date_time link=static architecture=x86 address-model=64
+
+      - name: Build wheel
+        run: |
+          BOOST_ROOT=./boost_${{ matrix.boost-version }}
+          export CC=clang
+          export CXX=clang++
+          export CFLAGS=-fvisibility=hidden # Match Boost build
+          export CFLAGS="$CFLAGS -Wno-unused-variable" # swig_obj
+          python setup.py build_ext -I$BOOST_ROOT -L$BOOST_ROOT/stage/lib -j2
+          python setup.py build
+          python setup.py bdist_wheel
+
+      - name: Log undefined symbols
+        run: |
+          PYMOD=$(echo build/lib.*/_pymmcore.*.so)
+
+          echo "$PYMOD:"
+          echo 'Weak symbols:'
+          nm -mu $PYMOD |c++filt |grep ' weak ' # This is never empty
+          echo '-- end of weak symbols --'
+
+          echo 'Undefined symbols not containing Py:'
+          # We have bash's -o pipefail set; make empty grep result mean success
+          ! nm -mu $PYMOD |c++filt |grep 'dynamically looked up' |grep -v _Py
+          echo '-- end of non-Py dynamically looked up symbols --'
+
+      - uses: actions/upload-artifact@v1
+        with:
+          name: wheel
+          path: dist

--- a/.github/workflows/wheel-macos.yml
+++ b/.github/workflows/wheel-macos.yml
@@ -7,6 +7,11 @@ jobs:
   build:
     runs-on: macos-latest
 
+    env:
+      # OS X 10.9 is the oldest version with libc++.
+      # See https://github.com/MacPython/wiki/wiki/Spinning-wheels#changing-your-wheel-compatibility
+      MACOSX_DEPLOYMENT_TARGET: 10.9
+
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/wheel-macos.yml
+++ b/.github/workflows/wheel-macos.yml
@@ -7,22 +7,24 @@ jobs:
   build:
     runs-on: macos-latest
 
-    env:
-      # OS X 10.9 is the oldest version with libc++.
-      # See https://github.com/MacPython/wiki/wiki/Spinning-wheels#changing-your-wheel-compatibility
-      MACOSX_DEPLOYMENT_TARGET: 10.9
-
     strategy:
       fail-fast: true
       matrix:
-        python-version: [3.8]
-        python-arch: [x64]
+        python-version: [3.8.2, 3.7.7, 3.6.7]
         boost-version: [1_72_0]
+        macos-version: [10.9]
         include:
-          - python-version: 3.8
+          - python-version: 3.8.2
             numpy-version: 1.17.3
+          - python-version: 3.7.7
+            numpy-version: 1.14.5
+          - python-version: 3.6.7
+            numpy-version: 1.12.0
 
-    name: macOS Python ${{ matrix.python-version }} ${{ matrix.python-arch }}
+    env:
+      MACOSX_DEPLOYMENT_TARGET: ${{ matrix.macos-version }}
+
+    name: macOS Python ${{ matrix.python-version }} x64
 
     steps:
 
@@ -33,10 +35,12 @@ jobs:
           git submodule sync --recursive
           git submodule update --init --force --recursive --depth=1
 
-      - uses: actions/setup-python@v1
-        with:
-          python-version: ${{ matrix.python-version }}
-          architecture: ${{ matrix.python-arch }}
+      - name: Install Python
+        run: |
+          curl -LO https://www.python.org/ftp/python/${{ matrix.python-version }}/python-${{ matrix.python-version }}-macosx${{ matrix.macos-version }}.pkg
+          sudo installer -pkg python-${{ matrix.python-version }}-macosx10.9.pkg -target /
+          PYTHON_VERSION=${{ matrix.python-version }}
+          /Library/Frameworks/Python.framework/Versions/${PYTHON_VERSION%.*}/bin/python3 -m venv venv
 
       - name: Install tools
         run: |
@@ -44,6 +48,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          source venv/bin/activate
           python -m pip install --upgrade pip
           python -m pip install --upgrade setuptools wheel
           python -m pip install numpy==${{ matrix.numpy-version }}
@@ -60,6 +65,7 @@ jobs:
 
       - name: Build wheel
         run: |
+          source venv/bin/activate
           BOOST_ROOT=./boost_${{ matrix.boost-version }}
           export CC=clang
           export CXX=clang++


### PR DESCRIPTION
It is likely that building on macOS 10.15 (the only version available with GitHub Actions) is actually safe -- to be tested.