### PR TITLE
add pyproject.toml for pep517/518 builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "numpy>=1.10.4"]

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ import distutils.command.build_ext
 import distutils.file_util
 import distutils.util
 import glob
+import numpy
 import os
 import setuptools
 
@@ -126,10 +127,6 @@ if is_windows:
     mmcore_defines.extend(windows_defines)
 
 
-def _get_includes():
-    import numpy
-    return [numpy.get_include()]
-
 mmcore_extension = setuptools.Extension(
     ext_mod_name,
     sources=mmcore_sources + [
@@ -143,7 +140,9 @@ mmcore_extension = setuptools.Extension(
         '-I./micro-manager/MMDevice',
         '-I./micro-manager/MMCore',
     ],
-    include_dirs=_get_includes(),
+    include_dirs=[
+        numpy.get_include(),
+    ],
     libraries=mmcore_libraries,
     define_macros=mmcore_defines,
 )

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ import distutils.command.build_ext
 import distutils.file_util
 import distutils.util
 import glob
-import numpy
 import os
 import setuptools
 
@@ -127,6 +126,10 @@ if is_windows:
     mmcore_defines.extend(windows_defines)
 
 
+def _get_includes():
+    import numpy
+    return [numpy.get_include()]
+
 mmcore_extension = setuptools.Extension(
     ext_mod_name,
     sources=mmcore_sources + [
@@ -140,9 +143,7 @@ mmcore_extension = setuptools.Extension(
         '-I./micro-manager/MMDevice',
         '-I./micro-manager/MMCore',
     ],
-    include_dirs=[
-        numpy.get_include(),
-    ],
+    include_dirs=_get_includes(),
     libraries=mmcore_libraries,
     define_macros=mmcore_defines,
 )


### PR DESCRIPTION
The `import numpy` in `setup.py` means that pip install (from source) from a clean env will fail.  Putting aside for the moment the challenges of building wheels anyway... how would you feel about adding this pyproject file that lets `pip install` attempt to build a wheel without numpy preinstalled?