### PR TITLE
Drop build test on Ubuntu 16.04; add 20.04

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        runner: [ubuntu-16.04, ubuntu-18.04]
+        runner: [ubuntu-18.04, ubuntu-20.04]
 
     name: ${{ matrix.runner }} build check
 


### PR DESCRIPTION
It looks like update from pip 8.1.1 (found in GitHub Actions' Ubuntu 16.04 build environment) to pip 21.0.1 fails. Since the reason for having the Ubuntu build is solely to demonstrate that a manual build on Ubuntu works, there is probably no reason to keep 16.04. Instead, add the newly available 20.04 environment.