### PR TITLE
Build wheels for 3.9

### DIFF
--- a/.github/workflows/manylinux.yml
+++ b/.github/workflows/manylinux.yml
@@ -19,7 +19,7 @@ jobs:
       AUDITWHEEL_PLAT: manylinux${{ matrix.manylinux-version }}_${{ matrix.arch }}
       DOCKER_IMAGE: quay.io/pypa/manylinux${{ matrix.manylinux-version }}_${{ matrix.arch }}
       BOOST_VERSION: ${{ matrix.boost-version }}
-      NUMPY_VERSIONS: cp35-cp35m 1.10.4 cp36-cp36m 1.12.0 cp37-cp37m 1.14.5 cp38-cp38 1.17.3
+      NUMPY_VERSIONS: cp35-cp35m 1.10.4 cp36-cp36m 1.12.0 cp37-cp37m 1.14.5 cp38-cp38 1.17.3 cp39-cp39 1.19.3
 
     steps:
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        runner: [ubuntu-18.04, ubuntu-20.04]
+        runner: [ubuntu-16.04, ubuntu-18.04]
 
     name: ${{ matrix.runner }} build check
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        runner: [ubuntu-16.04, ubuntu-18.04]
+        runner: [ubuntu-18.04, ubuntu-20.04]
 
     name: ${{ matrix.runner }} build check
 

--- a/.github/workflows/win-mac.yml
+++ b/.github/workflows/win-mac.yml
@@ -9,16 +9,14 @@ jobs:
       fail-fast: true
       matrix:
         # os: [Windows, macOS]
-        os: [macOS]
+        runner: [macos-latest]
         python-version: [3.9]
         python-arch: [x64]
         boost-version: [1_72_0]
         macos-version: [10.9]
-        include:
+        # include:
           # - os: Windows
           #   runner: windows-latest
-          - os: macOS
-            runner: macOS-latest
           # - python-version: 3.5
           #   numpy-version: 1.10.4
           # - python-version: 3.6

--- a/.github/workflows/win-mac.yml
+++ b/.github/workflows/win-mac.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        # os: [Windows, macOS]
+        os: [macOS]
         runner: [macos-latest]
         python-version: [3.9]
         python-arch: [x64]

--- a/.github/workflows/win-mac.yml
+++ b/.github/workflows/win-mac.yml
@@ -30,7 +30,7 @@ jobs:
             numpy-version: 1.17.3
           - python-version: 3.9
             mac-python-version: 3.9.1
-            numpy-version: 1.17.3
+            numpy-version: 1.19.3
           - python-arch: x64
             msvc-arch: amd64
           - python-arch: x86

--- a/.github/workflows/win-mac.yml
+++ b/.github/workflows/win-mac.yml
@@ -1,5 +1,6 @@
 name: Build Windows and macOS wheels
 
+
 on: [push]
 
 jobs:

--- a/.github/workflows/win-mac.yml
+++ b/.github/workflows/win-mac.yml
@@ -1,6 +1,5 @@
 name: Build Windows and macOS wheels
 
-
 on: [push]
 
 jobs:
@@ -8,35 +7,36 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [macOS]
-        runner: [macos-latest]
-        python-version: [3.9]
-        python-arch: [x64]
+        os: [Windows, macOS]
+        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-arch: [x64, x86]
         boost-version: [1_72_0]
         macos-version: [10.9]
-        # include:
-          # - os: Windows
-          #   runner: windows-latest
-          # - python-version: 3.5
-          #   numpy-version: 1.10.4
-          # - python-version: 3.6
-          #   mac-python-version: 3.6.7
-          #   numpy-version: 1.12.0
-          # - python-version: 3.7
-          #   mac-python-version: 3.7.7
-          #   numpy-version: 1.14.5
-          # - python-version: 3.8
-          #   mac-python-version: 3.8.2
-          #   numpy-version: 1.17.3
-          # - python-arch: x64
-          #   msvc-arch: amd64
-          # - python-arch: x86
-          #   msvc-arch: x86
-        # exclude:
-        #   - os: macOS
-        #     python-arch: x86
-        #   - os: macOS
-        #     python-version: 3.5
+        include:
+          - os: Windows
+            runner: windows-latest
+          - os: macOS
+            runner: macOS-latest
+          - python-version: 3.5
+            numpy-version: 1.10.4
+          - python-version: 3.6
+            mac-python-version: 3.6.7
+            numpy-version: 1.12.0
+          - python-version: 3.7
+            mac-python-version: 3.7.7
+            numpy-version: 1.14.5
+          - python-version: 3.8
+            mac-python-version: 3.8.2
+            numpy-version: 1.17.3
+          - python-arch: x64
+            msvc-arch: amd64
+          - python-arch: x86
+            msvc-arch: x86
+        exclude:
+          - os: macOS
+            python-arch: x86
+          - os: macOS
+            python-version: 3.5
 
     name: ${{ matrix.os }} Python ${{ matrix.python-version }} ${{ matrix.python-arch }}
 
@@ -56,19 +56,19 @@ jobs:
           git submodule update --init --force --recursive --depth=1
 
       - name: Install Python (generic)
-        uses: actions/setup-python@v2
-        # if: matrix.os != 'macOS'
+        uses: actions/setup-python@v1
+        if: matrix.os != 'macOS'
         with:
           python-version: ${{ matrix.python-version }}
           architecture: ${{ matrix.python-arch }}
 
-      # - name: Install Python (macOS)
-      #   if: matrix.os == 'macOS'
-      #   run: |
-      #     # Install Python.org Python
-      #     curl -LO https://www.python.org/ftp/python/${{ matrix.mac-python-version }}/python-${{ matrix.mac-python-version }}-macosx${{ matrix.macos-version }}.pkg
-      #     sudo installer -pkg python-${{ matrix.mac-python-version }}-macosx${{ matrix.macos-version }}.pkg -target /
-      #     /Library/Frameworks/Python.framework/Versions/${{ matrix.python-version }}/bin/python3 -m venv venv
+      - name: Install Python (macOS)
+        if: matrix.os == 'macOS'
+        run: |
+          # Install Python.org Python
+          curl -LO https://www.python.org/ftp/python/${{ matrix.mac-python-version }}/python-${{ matrix.mac-python-version }}-macosx${{ matrix.macos-version }}.pkg
+          sudo installer -pkg python-${{ matrix.mac-python-version }}-macosx${{ matrix.macos-version }}.pkg -target /
+          /Library/Frameworks/Python.framework/Versions/${{ matrix.python-version }}/bin/python3 -m venv venv
 
       - name: Install tools (Windows)
         if: matrix.os == 'Windows'

--- a/.github/workflows/win-mac.yml
+++ b/.github/workflows/win-mac.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [Windows, macOS]
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
         python-arch: [x64, x86]
         boost-version: [1_72_0]
         macos-version: [10.9]

--- a/.github/workflows/win-mac.yml
+++ b/.github/workflows/win-mac.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [Windows, macOS]
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
         python-arch: [x64, x86]
         boost-version: [1_72_0]
         macos-version: [10.9]
@@ -27,6 +27,9 @@ jobs:
             numpy-version: 1.14.5
           - python-version: 3.8
             mac-python-version: 3.8.2
+            numpy-version: 1.17.3
+          - python-version: 3.9
+            mac-python-version: 3.9.1
             numpy-version: 1.17.3
           - python-arch: x64
             msvc-arch: amd64

--- a/.github/workflows/win-mac.yml
+++ b/.github/workflows/win-mac.yml
@@ -11,7 +11,7 @@ jobs:
         # os: [Windows, macOS]
         os: [macOS]
         python-version: [3.9]
-        python-arch: [x64, x86]
+        python-arch: [x64]
         boost-version: [1_72_0]
         macos-version: [10.9]
         include:

--- a/.github/workflows/win-mac.yml
+++ b/.github/workflows/win-mac.yml
@@ -9,15 +9,16 @@ jobs:
       fail-fast: true
       matrix:
         # os: [Windows, macOS]
+        os: [macOS]
         python-version: [3.9]
         python-arch: [x64, x86]
         boost-version: [1_72_0]
         macos-version: [10.9]
-        include:
+        # include:
           # - os: Windows
           #   runner: windows-latest
-          - os: macOS
-            runner: macOS-latest
+          # - os: macOS
+          #   runner: macOS-latest
           # - python-version: 3.5
           #   numpy-version: 1.10.4
           # - python-version: 3.6
@@ -33,11 +34,11 @@ jobs:
           #   msvc-arch: amd64
           # - python-arch: x86
           #   msvc-arch: x86
-        exclude:
-          - os: macOS
-            python-arch: x86
-          - os: macOS
-            python-version: 3.5
+        # exclude:
+        #   - os: macOS
+        #     python-arch: x86
+        #   - os: macOS
+        #     python-version: 3.5
 
     name: ${{ matrix.os }} Python ${{ matrix.python-version }} ${{ matrix.python-arch }}
 

--- a/.github/workflows/win-mac.yml
+++ b/.github/workflows/win-mac.yml
@@ -14,11 +14,11 @@ jobs:
         python-arch: [x64, x86]
         boost-version: [1_72_0]
         macos-version: [10.9]
-        # include:
+        include:
           # - os: Windows
           #   runner: windows-latest
-          # - os: macOS
-          #   runner: macOS-latest
+          - os: macOS
+            runner: macOS-latest
           # - python-version: 3.5
           #   numpy-version: 1.10.4
           # - python-version: 3.6

--- a/.github/workflows/win-mac.yml
+++ b/.github/workflows/win-mac.yml
@@ -8,31 +8,31 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [Windows, macOS]
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
+        # os: [Windows, macOS]
+        python-version: [3.9]
         python-arch: [x64, x86]
         boost-version: [1_72_0]
         macos-version: [10.9]
         include:
-          - os: Windows
-            runner: windows-latest
+          # - os: Windows
+          #   runner: windows-latest
           - os: macOS
             runner: macOS-latest
-          - python-version: 3.5
-            numpy-version: 1.10.4
-          - python-version: 3.6
-            mac-python-version: 3.6.7
-            numpy-version: 1.12.0
-          - python-version: 3.7
-            mac-python-version: 3.7.7
-            numpy-version: 1.14.5
-          - python-version: 3.8
-            mac-python-version: 3.8.2
-            numpy-version: 1.17.3
-          - python-arch: x64
-            msvc-arch: amd64
-          - python-arch: x86
-            msvc-arch: x86
+          # - python-version: 3.5
+          #   numpy-version: 1.10.4
+          # - python-version: 3.6
+          #   mac-python-version: 3.6.7
+          #   numpy-version: 1.12.0
+          # - python-version: 3.7
+          #   mac-python-version: 3.7.7
+          #   numpy-version: 1.14.5
+          # - python-version: 3.8
+          #   mac-python-version: 3.8.2
+          #   numpy-version: 1.17.3
+          # - python-arch: x64
+          #   msvc-arch: amd64
+          # - python-arch: x86
+          #   msvc-arch: x86
         exclude:
           - os: macOS
             python-arch: x86
@@ -57,19 +57,19 @@ jobs:
           git submodule update --init --force --recursive --depth=1
 
       - name: Install Python (generic)
-        uses: actions/setup-python@v1
-        if: matrix.os != 'macOS'
+        uses: actions/setup-python@v2
+        # if: matrix.os != 'macOS'
         with:
           python-version: ${{ matrix.python-version }}
           architecture: ${{ matrix.python-arch }}
 
-      - name: Install Python (macOS)
-        if: matrix.os == 'macOS'
-        run: |
-          # Install Python.org Python
-          curl -LO https://www.python.org/ftp/python/${{ matrix.mac-python-version }}/python-${{ matrix.mac-python-version }}-macosx${{ matrix.macos-version }}.pkg
-          sudo installer -pkg python-${{ matrix.mac-python-version }}-macosx${{ matrix.macos-version }}.pkg -target /
-          /Library/Frameworks/Python.framework/Versions/${{ matrix.python-version }}/bin/python3 -m venv venv
+      # - name: Install Python (macOS)
+      #   if: matrix.os == 'macOS'
+      #   run: |
+      #     # Install Python.org Python
+      #     curl -LO https://www.python.org/ftp/python/${{ matrix.mac-python-version }}/python-${{ matrix.mac-python-version }}-macosx${{ matrix.macos-version }}.pkg
+      #     sudo installer -pkg python-${{ matrix.mac-python-version }}-macosx${{ matrix.macos-version }}.pkg -target /
+      #     /Library/Frameworks/Python.framework/Versions/${{ matrix.python-version }}/bin/python3 -m venv venv
 
       - name: Install tools (Windows)
         if: matrix.os == 'Windows'

--- a/maintainer-notes.md
+++ b/maintainer-notes.md
@@ -59,6 +59,7 @@ ABI Compatibility
   - Python 3.6 - NumPy 1.12.0
   - Python 3.7 - NumPy 1.14.5
   - Python 3.8 - NumPy 1.17.3
+  - Python 3.9 - NumPy 1.19.3
 
 
 ### Windows


### PR DESCRIPTION
Hi @marktsuchida @nicost, would love to have py3.9 wheels for pymmcore on pypi.  Wheels built and worked fine for me locally on mac 10.15 and 11.1 with py3.9.1, and they appear to be [building fine on CI](https://github.com/tlambert-forks/pymmcore/actions/runs/548460189) in this PR.

It's not clear to me from the github workflow how you're actually deploying to PyPI (i.e. whether you're manually using twine?).  I could try to set up an auto-deploy action here too... but you'd need to add your twine API key to the repo secrets.  (or, if you prefer to just upload manually that's fine too).

thanks