### PR TITLE
Include device interface version in version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ version_ must match between pymmcore and the Micro-Manager device adapters
 The device interface version of a given Micro-Manager installation can be
 viewed in **Help** > **About Micro-Manager**.
 
-The device interface version of a given pymmcore version can be viewed as
-follows:
+The device interface version of a given pymmcore version is the fourth part in
+the version number, and can also be viewed as follows:
 ```python
 import pymmcore
 pymmcore.CMMCore().getAPIVersionInfo()
@@ -82,11 +82,13 @@ Note that `getAPIVersionInfo()` should not be confused with `getVersionInfo()`,
 which returns the version number of MMCore. (The MMCore version is the first 3
 parts of the pymmcore version.)
 
-- For example, pymmcore `10.0.0.0` is based on MMCore `10.0.0`. That version of
-  MMCore had device interface version `69`.
-- Usually at least the last digit (patch version) of the MMCore version changes
-  when there is a change to the device interface version.
-- But several MMCore versions may share the same device interface version.
+- For example, pymmcore `10.1.1.69.0` is based on MMCore `10.1.1` and has
+  device interface version `69`.
+- The device interface version can change independently of the MMCore version,
+  although it is less common for the device interface version to be incremented
+  without a corresponding version change of MMCore.
+- Older versions of pymmcore did not include the device interface version in
+  their version number.
 
 For a list of device interface versions for each pymmcore version, see the
 [Releases](https://github.com/micro-manager/pymmcore/releases) page.

--- a/maintainer-notes.md
+++ b/maintainer-notes.md
@@ -1,14 +1,24 @@
 Versioning scheme
 -----------------
 
-Use MMCore version (not device interface version) with extra pymmcore-specific
-suffix. Cf. PEP 440.
+Cf. PEP 440.
 
-This correspondence is enforced in the smoke test.
+Concatenate the MMCore version, MMDevice device interface version, and an extra
+pymmcore-specific suffix. For example, pymmcore 10.1.1.69.0 wraps MMCore 10.1.1
+and works with device adapters built for device interface version 69. The
+final suffix can be incremented to create a new release for improvements to the
+pymmcore wrapper.
+
+(Note that the device interface version can change without a change to the
+MMCore version, although this is relatively uncommon. Also, we are leaving out
+the module interface version, which rarely changes.)
+
+The correspondence to MMCore and device interface versions is checked in the
+smoke test.
 
 Note that we can support multiple MMCore versions, possibly retroactively, by
 maintaining separate branches; this can ease transition when the device
-interface version changes. Such branches should be named `mmcore-x.y.z`.
+interface version changes. Such branches should be named `mmcore-x.y.z.w`.
 
 When upgrading the MMCore version (by bumping the micro-manager submodule
 commit), the pymmcore version in `setup.cfg` should be updated together.
@@ -21,15 +31,15 @@ Prepare two commits, one removing `dev` from the version and a subsequent one
 bumping to the next `dev` version. Push to master. Tag the (single) commit with
 the release version; the tag should be `v` prefixed to the version:
 ```bash
-git tag -a v1.2.3.4 $commit -m Release
-git push origin v1.2.3.4
+git tag -a v1.2.3.42.4 $commit -m Release
+git push origin v1.2.3.42.4
 ```
 
 This triggers a build, since our GitHub workflows build on push, including when
 it's an annotated tag. When the builds complete, download the artifacts and
 collect the wheels. Also locally prepare a source distribution:
 ```bash
-git checkout v1.2.3.4
+git checkout v1.2.3.42.4
 python setup.py sdist --format=zip
 ```
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pymmcore
-version = 10.1.1.1dev
+version = 10.1.1.69.0dev
 author = Micro-Manager Team
 author_email = info@micro-manager.org
 url = https://github.com/micro-manager/pymmcore

--- a/smoketest/smoke.py
+++ b/smoketest/smoke.py
@@ -5,7 +5,7 @@ import os.path
 
 
 #
-# At the moment, the only test is that our version number is correct
+# At the moment, the only test is that our version numbering is correct
 #
 
 
@@ -18,10 +18,24 @@ config.read(setup_cfg)
 pymmcore_version = config['metadata']['version'].split('.')
 print("Version: {}".format(pymmcore_version))
 
-# getVersionInfo() returns a string like "MMCore version x.y.z"
-mmcore_version = pymmcore.CMMCore().getVersionInfo().split()[-1].split('.')
+mmc = pymmcore.CMMCore()
+
+# getVersionInfo() returns a string like "MMCore version 10.1.1"
+mmcore_version = mmc.getVersionInfo().split()[-1].split('.')
 print("MMCore version: {}".format(mmcore_version))
 
 for i in range(3):
     if pymmcore_version[i] != mmcore_version[i]:
         raise AssertionError('Version mismatch between pymmcore and MMCore')
+
+
+# getAPIVersionInfo() returns a string like
+# "Device API version 69, Module API version 10"
+dev_if_version = mmc.getAPIVersionInfo().split(',')[0].split()[-1]
+mod_if_version = mmc.getAPIVersionInfo().split()[-1]
+print("MMDevice device interface version: {}".format(dev_if_version))
+print("MMDevice module interface version: {}".format(mod_if_version))
+
+if pymmcore_version[3] != dev_if_version:
+    raise AssertionError(
+            'Version mismatch between pymmcore and device interface')


### PR DESCRIPTION
The pymmcore version number now includes the device interface version.

Note that MMCore went from device interface version 69 to 70 while
keeping the MMCore version 10.1.1. This is relatively unusual, but
including the device interface version in the pymmcore version helps
working with this situation and is also probably generally helpful.