### PR TITLE
Update Boost source download URLs

### DIFF
--- a/.github/workflows/win-mac.yml
+++ b/.github/workflows/win-mac.yml
@@ -101,8 +101,9 @@ jobs:
           BOOST_VER=${{ matrix.boost-version }}
           BOOST_DOTS=${BOOST_VER//_/.}
           BOOST_TGZ=boost_$BOOST_VER.tar.gz
-          curl -fLO https://dl.bintray.com/boostorg/release/$BOOST_DOTS/source/$BOOST_TGZ || \
-              curl -fLO https://astuteinternet.dl.sourceforge.net/project/boost/boost/$BOOST_DOTS/$BOOST_TGZ
+          # Try official source and an (arbitrary) SourceForge mirror
+          curl -fLO https://boostorg.jfrog.io/artifactory/main/release/$BOOST_DOTS/source/$BOOST_TGZ || \
+              curl -fLO https://iweb.dl.sourceforge.net/project/boost/boost/$BOOST_DOTS/$BOOST_TGZ
           PATH="$PATH:/usr/bin/core_perl"  # shasum in Windows Git Bash
           # Windows shasum fails if file list contains DOS newlines
           tr -d '\015' <boost-sha256.txt >boost-sha256.unix.txt

--- a/manylinux/build.sh
+++ b/manylinux/build.sh
@@ -10,8 +10,9 @@ cd /
 
 BOOST_DOTS=${BOOST_VERSION//_/.}
 BOOST_TGZ=boost_$BOOST_VERSION.tar.gz
-curl -fLO https://dl.bintray.com/boostorg/release/$BOOST_DOTS/source/$BOOST_TGZ || \
-    curl -fLO https://astuteinternet.dl.sourceforge.net/project/boost/boost/$BOOST_DOTS/$BOOST_TGZ
+# Try official source and an (arbitrary) SourceForge mirror
+curl -fLO https://boostorg.jfrog.io/artifactory/main/release/$BOOST_DOTS/source/$BOOST_TGZ || \
+    curl -fLO https://iweb.dl.sourceforge.net/project/boost/boost/$BOOST_DOTS/$BOOST_TGZ
 sha256sum -c /io/boost-sha256.txt
 tar xzf $BOOST_TGZ
 pushd boost_$BOOST_VERSION


### PR DESCRIPTION
They moved; see
https://www.boost.org/users/news/boost_has_moved_downloads_to_jfr.html

Also replace a no-longer working SourceForge mirror.