### PR TITLE
Switch manylinux to manylinux2014

### DIFF
--- a/.github/workflows/manylinux.yml
+++ b/.github/workflows/manylinux.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        manylinux-version: ['2010'] # 2014 should be added when auditwheel fixed
+        manylinux-version: ['2014']
         arch: [i686, x86_64]
         boost-version: ['1_72_0']
 


### PR DESCRIPTION
manylinux2010 uses an EOL version of CentOS so needs to be retired (and should no longer be needed).

Build (auditwheel) failed previously (March 2020) with manylinux2014 but it now works.