### PR TITLE
Include SWIG interface file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,7 @@ dist/
 
 wheelhouse/
 
+pymmcore_wrap.h
+pymmcore_wrap.cpp
 pymmcore.py
 pymmcore.egg-info

--- a/MMCorePy.i
+++ b/MMCorePy.i
@@ -1,0 +1,309 @@
+///////////////////////////////////////////////////////////////////////////////
+// FILE:          MMCorePy.i
+// PROJECT:       Micro-Manager
+// SUBSYSTEM:     MMCorePy
+//-----------------------------------------------------------------------------
+// DESCRIPTION:   SWIG generator for the Python interface wrapper.
+//              
+// COPYRIGHT:     University of California, San Francisco, 2006,
+//                All Rights reserved
+//
+// LICENSE:       This file is distributed under the "Lesser GPL" (LGPL) license.
+//                License text is included with the source distribution.
+//
+//                This file is distributed in the hope that it will be useful,
+//                but WITHOUT ANY WARRANTY; without even the implied warranty
+//                of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//
+//                IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//                CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+//                INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
+//
+// AUTHOR:        Arthur Edelstein, arthuredelstein@gmail.com, 2009.08.11
+//                based on the java wrapper code by
+//                Nenad Amodaj, nenad@amodaj.com, 06/07/2005
+// 
+// CVS:           $Id: MMCorePy.i 2178 2009-02-27 13:08:53Z nenad $
+//
+
+
+
+
+
+%module (directors="1") MMCorePy
+%feature("director") MMEventCallback;
+%feature("autodoc", "3");
+
+%include exception.i
+%include std_string.i
+%include std_vector.i
+%include std_map.i
+%include std_pair.i
+%include "typemaps.i"
+
+%{
+#define SWIG_FILE_WITH_INIT
+%}
+
+%init %{
+import_array();
+%}
+
+%{
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#include "numpy/arrayobject.h"
+#include "string.h"
+%}
+
+%typemap(out) void*
+{
+   npy_intp dims[2];
+   dims[0] = (arg1)->getImageHeight();
+   dims[1] = (arg1)->getImageWidth();
+   npy_intp pixelCount = dims[0] * dims[1];
+
+   if ((arg1)->getBytesPerPixel() == 1)
+   {
+      PyObject * numpyArray = PyArray_SimpleNew(2, dims, NPY_UINT8);
+      memcpy(PyArray_DATA((PyArrayObject *) numpyArray), result, pixelCount);
+      $result = numpyArray;
+   }
+   else if ((arg1)->getBytesPerPixel() == 2)
+   {
+      PyObject * numpyArray = PyArray_SimpleNew(2, dims, NPY_UINT16);
+      memcpy(PyArray_DATA((PyArrayObject *) numpyArray), result, pixelCount * 2);
+      $result = numpyArray;
+   }
+   else if ((arg1)->getBytesPerPixel() == 4)
+   {
+      PyObject * numpyArray = PyArray_SimpleNew(2, dims, NPY_UINT32);
+      memcpy(PyArray_DATA((PyArrayObject *) numpyArray), result, pixelCount * 4);
+      $result = numpyArray;
+   }
+   else if ((arg1)->getBytesPerPixel() == 8)
+   {
+      PyObject * numpyArray = PyArray_SimpleNew(2, dims, NPY_UINT64);
+      memcpy(PyArray_DATA((PyArrayObject *) numpyArray), result, pixelCount * 8);
+      $result = numpyArray;
+   }
+   else
+   {
+      // don't know how to map
+      // TODO: thow exception?
+      // XXX Must do something, as returning NULL without setting error results
+      // in an opaque error.
+      $result = 0;
+   }
+}
+
+
+%typemap(out) unsigned int*
+{
+   //Here we assume we are getting RGBA (32 bits).
+   npy_intp dims[3];
+   dims[0] = (arg1)->getImageHeight();
+   dims[1] = (arg1)->getImageWidth();
+   dims[2] = 3; // RGB
+   unsigned numChannels = (arg1)->getNumberOfComponents();
+   unsigned char * pyBuf;
+   unsigned char * coreBuf = (unsigned char *) result;
+   
+   if ((arg1)->getBytesPerPixel() == 4 && numChannels == 1)
+   {
+
+	  // create new numpy array object
+      PyObject * numpyArray = PyArray_SimpleNew(3, dims, NPY_UINT8);
+
+	  // get a pointer to the data buffer
+	  pyBuf = (unsigned char *) PyArray_DATA((PyArrayObject *) numpyArray);
+
+	  // copy R,G,B but leave out A in RGBA to return a WxHx3-dimensional array
+
+	  long pixelCount = dims[0] * dims[1];         
+	  
+	  for (long i=0; i<pixelCount; ++i)
+	  {
+	     *pyBuf++ = *coreBuf++; //R
+	     *pyBuf++ = *coreBuf++; //G
+	     *pyBuf++ = *coreBuf++; //B
+
+	     ++coreBuf; // Skip the empty byte
+	  }
+	  
+	  // Return the numpy array object
+
+      $result = numpyArray;
+
+   }
+   else
+   {
+      // don't know how to map
+      // TODO: thow exception?
+      $result = 0;
+   }
+}
+
+/* tell SWIG to treat char ** as a list of strings */
+/* From https://stackoverflow.com/questions/3494598/passing-a-list-of-strings-to-from-python-ctypes-to-c-function-expecting-char */
+/* XXX No need to freearg the vector, right? */
+%typemap(in) std::vector<unsigned char *> {
+    // check if is a list
+    if(PyList_Check($input))
+    {
+        long expectedLength = (arg1)->getSLMWidth(arg2) * (arg1)->getSLMHeight(arg2);
+
+        Py_ssize_t size = PyList_Size($input);
+        std::vector<unsigned char*> inputVector;
+
+        for(Py_ssize_t i = 0; i < size; i++)
+        {
+            //printf("Pushing %d\n",  i);
+            PyObject * o = PyList_GetItem($input, i);
+            if(PyString_Check(o))
+            {
+                if (PyString_Size(o) != expectedLength)
+                {
+                    PyErr_SetString(PyExc_TypeError, "One of the Image strings is the wrong length for this SLM.");
+                    return NULL;
+                }
+   
+                inputVector.push_back((unsigned char *)PyString_AsString(o));
+            }
+            else
+            {
+                PyErr_SetString(PyExc_TypeError, "list must contain strings");
+                return NULL;
+            }
+        }
+        $1 = inputVector;
+    }
+    else
+    {
+        PyErr_SetString(PyExc_TypeError, "not a list");
+        return NULL;
+    }
+}
+
+%rename(setSLMImage) setSLMImage_pywrap;
+%apply (char *STRING, int LENGTH) { (char *pixels, int receivedLength) };
+%extend CMMCore {
+PyObject *setSLMImage_pywrap(const char* slmLabel, char *pixels, int receivedLength)
+{
+   long expectedLength = self->getSLMWidth(slmLabel) * self->getSLMHeight(slmLabel);
+   //printf("expected: %d -- received: %d\n",expectedLength,receivedLength);
+
+   if (receivedLength == expectedLength)
+   {
+      self->setSLMImage(slmLabel, (unsigned char *)pixels);
+   }
+   else if (receivedLength == 4*expectedLength)
+   {
+      self->setSLMImage(slmLabel, (imgRGB32)pixels);
+   }
+   else
+   {
+      PyErr_SetString(PyExc_TypeError, "Image dimensions are wrong for this SLM.");
+      return (PyObject *) NULL;
+   }
+   return PyInt_FromLong(0);
+}
+}
+%ignore setSLMImage;
+
+%{
+#define SWIG_FILE_WITH_INIT
+#include "../MMDevice/MMDeviceConstants.h"
+#include "../MMCore/Error.h"
+#include "../MMCore/Configuration.h"
+#include "../MMDevice/ImageMetadata.h"
+#include "../MMCore/MMEventCallback.h"
+#include "../MMCore/MMCore.h"
+%}
+
+// Map Error codes to the appropriate python error type, and populate error message.
+// NOTE: direct use of the %exception directive will not work in most cases because
+// of the way SWIG parses a C++ method with a `throws` specification (used frequently in MM)
+%typemap(throws) CMMError %{
+    CMMError e = $1;
+    switch (e.getCode())
+    {
+        case MMERR_OK:
+            break;
+        case MMERR_BadAffineTransform:
+        case MMERR_BadConfigName:
+        case MMERR_DuplicateConfigGroup:
+        case MMERR_DuplicateLabel:
+        case MMERR_InvalidContents:
+        case MMERR_InvalidCoreProperty:
+        case MMERR_InvalidCoreValue:
+        case MMERR_InvalidLabel:
+        case MMERR_InvalidPropertyBlock:
+        case MMERR_InvalidSerialDevice:
+        case MMERR_InvalidShutterDevice:
+        case MMERR_InvalidSpecificDevice:
+        case MMERR_InvalidStageDevice:
+        case MMERR_InvalidStateDevice:
+        case MMERR_InvalidXYStageDevice:
+        case MMERR_NoConfigGroup:
+        case MMERR_NoConfiguration:
+        case MMERR_NullPointerException:
+        case MMERR_PropertyNotInCache:
+        case MMERR_SetPropertyFailed:
+        case MMERR_UnexpectedDevice:
+            SWIG_exception(SWIG_ValueError, e.what());
+        case MMERR_FileOpenFailed:
+        case MMERR_InvalidCFGEntry:
+        case MMERR_InvalidConfigurationFile:
+        case MMERR_LoadLibraryFailed:
+            SWIG_exception(SWIG_IOError, e.what());
+        case MMERR_CircularBufferEmpty:
+        case MMERR_InvalidConfigurationIndex:
+            SWIG_exception(SWIG_IndexError, e.what());
+        case MMERR_CircularBufferFailedToInitialize:
+        case MMERR_OutOfMemory:
+            SWIG_exception(SWIG_MemoryError, e.what());
+        case MMERR_CameraBufferReadFailed:
+        case MMERR_CircularBufferIncompatibleImage:
+        case MMERR_UnhandledException:
+        case MMERR_UnknownModule:
+        default:
+            SWIG_exception(SWIG_RuntimeError, e.what());
+    }
+%}
+
+%typemap(throws) MetadataKeyError %{
+    SWIG_exception(SWIG_ValueError, ($1).getMsg().c_str());
+%}
+
+%typemap(throws) MetadataIndexError %{
+    SWIG_exception(SWIG_IndexError, ($1).getMsg().c_str());
+%}
+
+
+
+// instantiate STL mappings
+namespace std {
+    %template(CharVector)   vector<char>;
+    %template(LongVector)   vector<long>;
+    %template(DoubleVector) vector<double>;
+    %template(StrVector)    vector<string>;
+    %template(pair_ss)      pair<string, string>;
+    %template(StrMap)       map<string, string>;
+}
+
+
+// output arguments
+%apply double &OUTPUT { double &x_stage };
+%apply double &OUTPUT { double &y_stage };
+%apply int &OUTPUT { int &x };
+%apply int &OUTPUT { int &y };
+%apply int &OUTPUT { int &xSize };
+%apply int &OUTPUT { int &ySize };
+
+
+%include "../MMDevice/MMDeviceConstants.h"
+%include "../MMCore/Error.h"
+%include "../MMCore/Configuration.h"
+%include "../MMCore/MMCore.h"
+%include "../MMDevice/ImageMetadata.h"
+%include "../MMCore/MMEventCallback.h"

--- a/pymmcore.i
+++ b/pymmcore.i
@@ -27,7 +27,6 @@
 //          source tree (pymmcore) after mmCoreAndDevices commit
 //          5fbfe334730583fc5bd86af875f278f76f88b34d (2021-05-06).
 
-
 %module (directors="1") MMCorePy
 %feature("director") MMEventCallback;
 %feature("autodoc", "3");
@@ -55,90 +54,90 @@ import_array();
 
 %typemap(out) void*
 {
-   npy_intp dims[2];
-   dims[0] = (arg1)->getImageHeight();
-   dims[1] = (arg1)->getImageWidth();
-   npy_intp pixelCount = dims[0] * dims[1];
+    npy_intp dims[2];
+    dims[0] = (arg1)->getImageHeight();
+    dims[1] = (arg1)->getImageWidth();
+    npy_intp pixelCount = dims[0] * dims[1];
 
-   if ((arg1)->getBytesPerPixel() == 1)
-   {
-      PyObject * numpyArray = PyArray_SimpleNew(2, dims, NPY_UINT8);
-      memcpy(PyArray_DATA((PyArrayObject *) numpyArray), result, pixelCount);
-      $result = numpyArray;
-   }
-   else if ((arg1)->getBytesPerPixel() == 2)
-   {
-      PyObject * numpyArray = PyArray_SimpleNew(2, dims, NPY_UINT16);
-      memcpy(PyArray_DATA((PyArrayObject *) numpyArray), result, pixelCount * 2);
-      $result = numpyArray;
-   }
-   else if ((arg1)->getBytesPerPixel() == 4)
-   {
-      PyObject * numpyArray = PyArray_SimpleNew(2, dims, NPY_UINT32);
-      memcpy(PyArray_DATA((PyArrayObject *) numpyArray), result, pixelCount * 4);
-      $result = numpyArray;
-   }
-   else if ((arg1)->getBytesPerPixel() == 8)
-   {
-      PyObject * numpyArray = PyArray_SimpleNew(2, dims, NPY_UINT64);
-      memcpy(PyArray_DATA((PyArrayObject *) numpyArray), result, pixelCount * 8);
-      $result = numpyArray;
-   }
-   else
-   {
-      // don't know how to map
-      // TODO: thow exception?
-      // XXX Must do something, as returning NULL without setting error results
-      // in an opaque error.
-      $result = 0;
-   }
+    if ((arg1)->getBytesPerPixel() == 1)
+    {
+        PyObject * numpyArray = PyArray_SimpleNew(2, dims, NPY_UINT8);
+        memcpy(PyArray_DATA((PyArrayObject *) numpyArray), result, pixelCount);
+        $result = numpyArray;
+    }
+    else if ((arg1)->getBytesPerPixel() == 2)
+    {
+        PyObject * numpyArray = PyArray_SimpleNew(2, dims, NPY_UINT16);
+        memcpy(PyArray_DATA((PyArrayObject *) numpyArray), result, pixelCount * 2);
+        $result = numpyArray;
+    }
+    else if ((arg1)->getBytesPerPixel() == 4)
+    {
+        PyObject * numpyArray = PyArray_SimpleNew(2, dims, NPY_UINT32);
+        memcpy(PyArray_DATA((PyArrayObject *) numpyArray), result, pixelCount * 4);
+        $result = numpyArray;
+    }
+    else if ((arg1)->getBytesPerPixel() == 8)
+    {
+        PyObject * numpyArray = PyArray_SimpleNew(2, dims, NPY_UINT64);
+        memcpy(PyArray_DATA((PyArrayObject *) numpyArray), result, pixelCount * 8);
+        $result = numpyArray;
+    }
+    else
+    {
+        // don't know how to map
+        // TODO: thow exception?
+        // XXX Must do something, as returning NULL without setting error results
+        // in an opaque error.
+        $result = 0;
+    }
 }
 
 
 %typemap(out) unsigned int*
 {
-   //Here we assume we are getting RGBA (32 bits).
-   npy_intp dims[3];
-   dims[0] = (arg1)->getImageHeight();
-   dims[1] = (arg1)->getImageWidth();
-   dims[2] = 3; // RGB
-   unsigned numChannels = (arg1)->getNumberOfComponents();
-   unsigned char * pyBuf;
-   unsigned char * coreBuf = (unsigned char *) result;
+    //Here we assume we are getting RGBA (32 bits).
+    npy_intp dims[3];
+    dims[0] = (arg1)->getImageHeight();
+    dims[1] = (arg1)->getImageWidth();
+    dims[2] = 3; // RGB
+    unsigned numChannels = (arg1)->getNumberOfComponents();
+    unsigned char * pyBuf;
+    unsigned char * coreBuf = (unsigned char *) result;
 
-   if ((arg1)->getBytesPerPixel() == 4 && numChannels == 1)
-   {
+    if ((arg1)->getBytesPerPixel() == 4 && numChannels == 1)
+    {
 
-	  // create new numpy array object
-      PyObject * numpyArray = PyArray_SimpleNew(3, dims, NPY_UINT8);
+        // create new numpy array object
+        PyObject * numpyArray = PyArray_SimpleNew(3, dims, NPY_UINT8);
 
-	  // get a pointer to the data buffer
-	  pyBuf = (unsigned char *) PyArray_DATA((PyArrayObject *) numpyArray);
+        // get a pointer to the data buffer
+        pyBuf = (unsigned char *) PyArray_DATA((PyArrayObject *) numpyArray);
 
-	  // copy R,G,B but leave out A in RGBA to return a WxHx3-dimensional array
+        // copy R,G,B but leave out A in RGBA to return a WxHx3-dimensional array
 
-	  long pixelCount = dims[0] * dims[1];
+        long pixelCount = dims[0] * dims[1];
 
-	  for (long i=0; i<pixelCount; ++i)
-	  {
-	     *pyBuf++ = *coreBuf++; //R
-	     *pyBuf++ = *coreBuf++; //G
-	     *pyBuf++ = *coreBuf++; //B
+        for (long i=0; i<pixelCount; ++i)
+        {
+            *pyBuf++ = *coreBuf++; //R
+            *pyBuf++ = *coreBuf++; //G
+            *pyBuf++ = *coreBuf++; //B
 
-	     ++coreBuf; // Skip the empty byte
-	  }
+            ++coreBuf; // Skip the empty byte
+        }
 
-	  // Return the numpy array object
+        // Return the numpy array object
 
-      $result = numpyArray;
+        $result = numpyArray;
 
-   }
-   else
-   {
-      // don't know how to map
-      // TODO: thow exception?
-      $result = 0;
-   }
+    }
+    else
+    {
+        // don't know how to map
+        // TODO: thow exception?
+        $result = 0;
+    }
 }
 
 /* tell SWIG to treat char ** as a list of strings */
@@ -187,23 +186,23 @@ import_array();
 %extend CMMCore {
 PyObject *setSLMImage_pywrap(const char* slmLabel, char *pixels, int receivedLength)
 {
-   long expectedLength = self->getSLMWidth(slmLabel) * self->getSLMHeight(slmLabel);
-   //printf("expected: %d -- received: %d\n",expectedLength,receivedLength);
+    long expectedLength = self->getSLMWidth(slmLabel) * self->getSLMHeight(slmLabel);
+    //printf("expected: %d -- received: %d\n",expectedLength,receivedLength);
 
-   if (receivedLength == expectedLength)
-   {
-      self->setSLMImage(slmLabel, (unsigned char *)pixels);
-   }
-   else if (receivedLength == 4*expectedLength)
-   {
-      self->setSLMImage(slmLabel, (imgRGB32)pixels);
-   }
-   else
-   {
-      PyErr_SetString(PyExc_TypeError, "Image dimensions are wrong for this SLM.");
-      return (PyObject *) NULL;
-   }
-   return PyInt_FromLong(0);
+    if (receivedLength == expectedLength)
+    {
+        self->setSLMImage(slmLabel, (unsigned char *)pixels);
+    }
+    else if (receivedLength == 4*expectedLength)
+    {
+        self->setSLMImage(slmLabel, (imgRGB32)pixels);
+    }
+    else
+    {
+        PyErr_SetString(PyExc_TypeError, "Image dimensions are wrong for this SLM.");
+        return (PyObject *) NULL;
+    }
+    return PyInt_FromLong(0);
 }
 }
 %ignore setSLMImage;
@@ -277,8 +276,6 @@ PyObject *setSLMImage_pywrap(const char* slmLabel, char *pixels, int receivedLen
     SWIG_exception(SWIG_IndexError, ($1).getMsg().c_str());
 %}
 
-
-
 // instantiate STL mappings
 namespace std {
     %template(CharVector)   vector<char>;
@@ -289,7 +286,6 @@ namespace std {
     %template(StrMap)       map<string, string>;
 }
 
-
 // output arguments
 %apply double &OUTPUT { double &x_stage };
 %apply double &OUTPUT { double &y_stage };
@@ -297,7 +293,6 @@ namespace std {
 %apply int &OUTPUT { int &y };
 %apply int &OUTPUT { int &xSize };
 %apply int &OUTPUT { int &ySize };
-
 
 %include "mmCoreAndDevices/MMDevice/MMDeviceConstants.h"
 %include "mmCoreAndDevices/MMCore/Error.h"

--- a/pymmcore.i
+++ b/pymmcore.i
@@ -1,33 +1,31 @@
-///////////////////////////////////////////////////////////////////////////////
-// FILE:          MMCorePy.i
-// PROJECT:       Micro-Manager
-// SUBSYSTEM:     MMCorePy
-//-----------------------------------------------------------------------------
-// DESCRIPTION:   SWIG generator for the Python interface wrapper.
-//              
-// COPYRIGHT:     University of California, San Francisco, 2006,
-//                All Rights reserved
+// SWIG interface file for MMCore Python bindings
 //
-// LICENSE:       This file is distributed under the "Lesser GPL" (LGPL) license.
-//                License text is included with the source distribution.
+// Copyright (C) 2006-2021 Regents of the University of California
+//           (C) 2020-2021 Board of Regents of the University of Wisconsin
+//                         System
 //
-//                This file is distributed in the hope that it will be useful,
-//                but WITHOUT ANY WARRANTY; without even the implied warranty
-//                of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// This library is free software; you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License, version 2.1, as
+// published by the Free Software Foundation.
 //
-//                IN NO EVENT SHALL THE COPYRIGHT OWNER OR
-//                CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-//                INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
+// This library is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+// for more details.
 //
-// AUTHOR:        Arthur Edelstein, arthuredelstein@gmail.com, 2009.08.11
-//                based on the java wrapper code by
-//                Nenad Amodaj, nenad@amodaj.com, 06/07/2005
-// 
-// CVS:           $Id: MMCorePy.i 2178 2009-02-27 13:08:53Z nenad $
+// You should have received a copy of the GNU Lesser General Public License
+// along with this library; if not, write to the Free Software Foundation,
+// Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 //
-
-
-
+// Author:  Arthur Edelstein, arthuredelstein@gmail.com, 2009.08.11,
+//          based on the Java wrapper code by
+//          Nenad Amodaj, nenad@amodaj.com, 06/07/2005, and
+//          Micro-Manager team and contributors.
+//
+// History: This file used to be part of the micro-manager source tree; then
+//          part of the mmCoreAndDevices source tree. It was moved to this
+//          source tree (pymmcore) after mmCoreAndDevices commit
+//          5fbfe334730583fc5bd86af875f278f76f88b34d (2021-05-06).
 
 
 %module (directors="1") MMCorePy
@@ -107,7 +105,7 @@ import_array();
    unsigned numChannels = (arg1)->getNumberOfComponents();
    unsigned char * pyBuf;
    unsigned char * coreBuf = (unsigned char *) result;
-   
+
    if ((arg1)->getBytesPerPixel() == 4 && numChannels == 1)
    {
 
@@ -119,8 +117,8 @@ import_array();
 
 	  // copy R,G,B but leave out A in RGBA to return a WxHx3-dimensional array
 
-	  long pixelCount = dims[0] * dims[1];         
-	  
+	  long pixelCount = dims[0] * dims[1];
+
 	  for (long i=0; i<pixelCount; ++i)
 	  {
 	     *pyBuf++ = *coreBuf++; //R
@@ -129,7 +127,7 @@ import_array();
 
 	     ++coreBuf; // Skip the empty byte
 	  }
-	  
+
 	  // Return the numpy array object
 
       $result = numpyArray;
@@ -166,7 +164,7 @@ import_array();
                     PyErr_SetString(PyExc_TypeError, "One of the Image strings is the wrong length for this SLM.");
                     return NULL;
                 }
-   
+
                 inputVector.push_back((unsigned char *)PyString_AsString(o));
             }
             else
@@ -212,12 +210,12 @@ PyObject *setSLMImage_pywrap(const char* slmLabel, char *pixels, int receivedLen
 
 %{
 #define SWIG_FILE_WITH_INIT
-#include "../MMDevice/MMDeviceConstants.h"
-#include "../MMCore/Error.h"
-#include "../MMCore/Configuration.h"
-#include "../MMDevice/ImageMetadata.h"
-#include "../MMCore/MMEventCallback.h"
-#include "../MMCore/MMCore.h"
+#include "mmCoreAndDevices/MMDevice/MMDeviceConstants.h"
+#include "mmCoreAndDevices/MMCore/Error.h"
+#include "mmCoreAndDevices/MMCore/Configuration.h"
+#include "mmCoreAndDevices/MMDevice/ImageMetadata.h"
+#include "mmCoreAndDevices/MMCore/MMEventCallback.h"
+#include "mmCoreAndDevices/MMCore/MMCore.h"
 %}
 
 // Map Error codes to the appropriate python error type, and populate error message.
@@ -301,9 +299,9 @@ namespace std {
 %apply int &OUTPUT { int &ySize };
 
 
-%include "../MMDevice/MMDeviceConstants.h"
-%include "../MMCore/Error.h"
-%include "../MMCore/Configuration.h"
-%include "../MMCore/MMCore.h"
-%include "../MMDevice/ImageMetadata.h"
-%include "../MMCore/MMEventCallback.h"
+%include "mmCoreAndDevices/MMDevice/MMDeviceConstants.h"
+%include "mmCoreAndDevices/MMCore/Error.h"
+%include "mmCoreAndDevices/MMCore/Configuration.h"
+%include "mmCoreAndDevices/MMCore/MMCore.h"
+%include "mmCoreAndDevices/MMDevice/ImageMetadata.h"
+%include "mmCoreAndDevices/MMCore/MMEventCallback.h"

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,7 @@
 # Setup for pymmcore
 #
-# Author: Mark Tsuchida
-#
-# Copyright (C) 2020 Board of Regents of the University of Wisconsin System
+# Copyright (C) 2020-2021 Board of Regents of the University of Wisconsin
+#                         System
 #
 # This library is free software; you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License, version 2.1, as published
@@ -16,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this library; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# Author: Mark A. Tsuchida
 
 import distutils.command.build_ext
 import distutils.file_util
@@ -40,9 +41,6 @@ class build_ext(distutils.command.build_ext.build_ext):
     def run(self):
         self.run_command('build_clib')
         distutils.command.build_ext.build_ext.run(self)
-        distutils.file_util.copy_file(
-            'mmCoreAndDevices/MMCorePy_wrap/' + py_mod_name + '.py',
-            py_mod_name + '.py')
 
 
 is_windows = distutils.util.get_platform().startswith('win')
@@ -130,7 +128,7 @@ if is_windows:
 mmcore_extension = setuptools.Extension(
     ext_mod_name,
     sources=mmcore_sources + [
-        'mmCoreAndDevices/MMCorePy_wrap/MMCorePy.i',
+        'pymmcore.i',
     ],
     swig_opts=[
         '-c++',


### PR DESCRIPTION
Copy the SWIG `.i` file from mmCoreAndDevices, in preparation for its removal from mmCoreAndDevices.
See micro-manager/mmCoreAndDevices#10.