### PR TITLE
Remove version from Windows SWIG

### DIFF
--- a/.github/workflows/win-mac.yml
+++ b/.github/workflows/win-mac.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Install tools (Windows)
         if: matrix.os == 'Windows'
         run: |
-          choco install -y swig --version 4.0.1
+          choco install -y swig
 
       - name: Install tools (macOS)
         if: matrix.os == 'macOS'


### PR DESCRIPTION
Was getting error that newer version (4.0.2) is already installed.