### PR TITLE
Exclude 32-bit Windows build for Python 3.10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,6 +144,9 @@ jobs:
         exclude:
           - os: macOS
             python-arch: x86
+          - os: Windows  # NumPy has 64-bit only for Windows wheels >= cp310
+            python-version: '3.10'
+            python-arch: x86
 
     name: ${{ matrix.os }} Python ${{ matrix.python-version }} ${{ matrix.python-arch }}
 

--- a/maintainer-notes.md
+++ b/maintainer-notes.md
@@ -70,7 +70,7 @@ ABI Compatibility
   - Python 3.7 - NumPy 1.14.5
   - Python 3.8 - NumPy 1.17.3
   - Python 3.9 - NumPy 1.19.3
-  - Python 3.10 - NumPy 1.21.3
+  - Python 3.10 - NumPy 1.21.3 (Windows: amd64 only)
 
 
 ### Windows


### PR DESCRIPTION
NumPy (1.21.3 and later) does not provide wheels for 32-bit Windows for cp310, so let us also drop support.