### PR TITLE
Drop build for 32-bit Python 3.10 on Linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,6 +73,11 @@ jobs:
         manylinux-version: ['2014']
         arch: [i686, x86_64]
         boost-version: ['1_78_0']
+        include:
+          - arch: i686
+            numpy-versions: cp37-cp37m 1.14.5 cp38-cp38 1.17.3 cp39-cp39 1.19.3
+          - arch: x86_64
+            numpy-versions: cp37-cp37m 1.14.5 cp38-cp38 1.17.3 cp39-cp39 1.19.3 cp310-cp310 1.21.3
 
     name: manylinux${{ matrix.manylinux-version }}_${{ matrix.arch }}
 
@@ -82,7 +87,7 @@ jobs:
       AUDITWHEEL_PLAT: manylinux${{ matrix.manylinux-version }}_${{ matrix.arch }}
       DOCKER_IMAGE: quay.io/pypa/manylinux${{ matrix.manylinux-version }}_${{ matrix.arch }}
       BOOST_VERSION: ${{ matrix.boost-version }}
-      NUMPY_VERSIONS: cp37-cp37m 1.14.5 cp38-cp38 1.17.3 cp39-cp39 1.19.3 cp310-cp310 1.21.3
+      NUMPY_VERSIONS: ${{ matrix.numpy-versions }}
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Installing
 ----------
 
 Windows (Python 3.7-3.10), macOS (Python 3.7-3.10, 64-bit), and Linux (Python
-3.7-3.10) are supported.
+3.7-3.10) are supported. Only 64-bit is supported for Python 3.10 and later.
 
 ```
 python -m pip install --user pymmcore


### PR DESCRIPTION
NumPy does not provide 32-bit wheels for Python 3.10.