### PR TITLE
fix: update dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update && apt-get install -y \
         software-properties-common \
         unzip \
         wget \
+        libboost-all-dev \ 
         && \
     apt-get clean && \
     apt-get autoremove && \
@@ -27,15 +28,16 @@ RUN apt-get update && apt-get install -y \
 RUN addgroup --gid 1001 python && \
     useradd --uid 1001 --gid 1001 python
 
-RUN git clone https://github.com/micro-manager/micro-manager.git
-RUN cd micro-manager && \
+RUN git clone https://github.com/micro-manager/micro-manager.git && \
+    cd micro-manager && \
+    git submodule update --init --recursive && \
     ./autogen.sh && \
     ./configure --without-java && \
     make && \
-    # will be installed to /usr/local/lib/micro-manager/
     make install
 ENV MMCORE_PATH=/usr/local/lib/micro-manager/
 ENV MMCONFIG_DEMO_PATH=/micro-manager/bindist/any-platform/MMConfig_demo.cfg
+RUN cp $MMCONFIG_DEMO_PATH $MMCORE_PATH/MMConfig_demo.cfg
 
 # Install miniconda to /miniconda
 RUN curl -LO https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
@@ -44,6 +46,6 @@ RUN rm Miniconda3-latest-Linux-x86_64.sh
 ENV PATH=/miniconda/bin:${PATH}
 
 RUN conda update -y conda && \
-    conda install -y python=3.7.6 numpy && \
+    conda install -y python=3.10 numpy && \
     pip install --upgrade pip && \
     pip install pymmcore


### PR DESCRIPTION
The dockerfile was failing for two reasons:

1. Wasn't properly downloading the mmCoreAndDevices submodule
2. seems libboost is still needed


@marktsuchida is there any clever way we could change this to only include the democamera rather than every device adapter?