### PR TITLE
Set GitHub environment for release to PyPI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     # upload to PyPI on every tag
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    environment: release
 
     # https://docs.pypi.org/trusted-publishers/
     permissions:


### PR DESCRIPTION
Use the 'release' environment, which is currently set to only allow tags matching `v*`. Mostly just provides future configuration flexibility.