### PR TITLE
Re-add compiler and linker flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,10 @@ jobs:
         uses: pypa/cibuildwheel@v2.16
         env:
           CIBW_ARCHS_MACOS: "${{ matrix.macos_arch }}"
+          # Python on Linux is usually configured to add debug information,
+          # which increases binary size by ~11-fold. Remove for the builds we
+          # distribute.
+          CIBW_ENVIRONMENT_LINUX: "LDFLAGS=-Wl,--strip-debug"
 
       - uses: actions/upload-artifact@v3
         with:

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ if not IS_WINDOWS:
 if not IS_WINDOWS:
     cflags = ["-std=c++14"]
     if "CFLAGS" in os.environ:
-        cflags.insert(0, os.environ["CFLAGS"])
+        cflags.append(os.environ["CFLAGS"])
     os.environ["CFLAGS"] = " ".join(cflags)
 
 

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,12 @@ if not IS_WINDOWS:
     mmcore_libraries.extend(["dl"])
 
 if not IS_WINDOWS:
-    cflags = ["-std=c++14"]
+    cflags = [
+        "-std=c++14",
+        "-fvisibility=hidden",
+        "-Wno-deprecated",       # Hide warnings for throw() specififiers
+        "-Wno-unused-variable",  # Hide warnings for SWIG-generated code
+    ]
     if "CFLAGS" in os.environ:
         cflags.append(os.environ["CFLAGS"])
     os.environ["CFLAGS"] = " ".join(cflags)


### PR DESCRIPTION
Some compiler flags got dropped during the switch to cibuildwheel, so re-add them:
- On Linux (CI only, not in default), remove debug information from the binary (this should restore the ~1 MiB wheels instead of the ~11 MiB we currently get)
- On macOS and Linux, set the default symbol visibility to hidden
- On macOS and Linux, suppress the noisy warnings from MMCore (exception specifiers) and SWIG (unused variables)
- Also reposition where `CFLAGS` is inserted into the command line so that the default flags can be overridden

None of these are necessary for correct functioning, so the binaries built without them are okay.