### PR TITLE
License was wrong in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ description = "Python bindings for MMCore, Micro-Manager's device control layer"
 dynamic = ["version"]
 readme = "README.md"
 requires-python = ">=3.8"
-license = { text = "BSD 3-Clause License" }
+license = { text = "LGPL-2.1-only" }
 authors = [{ name = "Micro-Manager Team" }]
 classifiers = [
     "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
(But was correct in the classifiers, so PyPI was displaying LPGL correctly.)