### PR TITLE
Upgrade MMDevice/MMCore and fix macro defs

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,4 +9,4 @@ prune mmCoreAndDevices/DeviceAdapters
 prune mmCoreAndDevices/m4
 prune mmCoreAndDevices/.github
 recursive-exclude mmCoreAndDevices *.txt *.md *.am .project \
-    *.vcxproj* *.sln *.props *.cdt* secret-device-*
+    *.vcxproj* *.sln *.props *.cdt* secret-device-* meson.build *.wrap

--- a/setup.py
+++ b/setup.py
@@ -57,24 +57,18 @@ class build_ext(setuptools.command.build_ext.build_ext):
         super().run()
 
 
+define_macros = [
+    ("MMDEVICE_CLIENT_BUILD", None),
+] + ([
+    ("NOMINMAX", None),
+    ("_CRT_SECURE_NO_WARNINGS", None),
+] if IS_WINDOWS else [])
+
 mmdevice_build_info = {
     "sources": [str(x.relative_to(ROOT)) for x in MMDevicePath.glob("*.cpp")],
     "include_dirs": ["mmCoreAndDevices/MMDevice"],
-    "macros": [("MODULE_EXPORTS", None)],
+    "macros": define_macros,
 }
-
-if IS_WINDOWS:
-    define_macros = [
-        ("_CRT_SECURE_NO_WARNINGS", None),
-        # These would not be necessary if _WIN32 or _MSC_VER were used correctly.
-        ("WIN32", None),
-        ("_WINDOWS", None),
-        # See DeviceUtils.h
-        ("MMDEVICE_NO_GETTIMEOFDAY", None),
-    ]
-    mmdevice_build_info["macros"].extend(define_macros)
-else:
-    define_macros = []
 
 omit = ["unittest"] + (["Unix"] if IS_WINDOWS else ["Windows"])
 mmcore_sources = [


### PR DESCRIPTION
This pulls in the changes up to https://github.com/micro-manager/mmCoreAndDevices/pull/435 and updates the preprocessor macros in setup.py accordingly:

- `MODULE_EXPORTS` removed from MMDevice build (this was previously needed to compile on Windows, even though semantically wrong)
- `MMDEVICE_CLIENT_BUILD` added to entire build
- `WIN32` and `_WINDOWS` removed, as these are no longer depended on by MMDevice/MMCore source
- `MMDEVICE_NO_GETTIMEOFDAY` removed, as MMDevice removed `gettimeofday()`
- `NOMINMAX` added on Windows, as MMCore (theoretically) requires it

---

- [x] Update the mmCoreAndDevices subproject to a merged commit (this PR started with it pointing to a branch commit)