### PR TITLE
Require SWIG 4.1 and use -python, not -py3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 # https://peps.python.org/pep-0517/
 [build-system]
-requires = ["setuptools >=61.0.0", "swig >=4", "oldest-supported-numpy"]
+requires = ["setuptools >=61.0.0", "swig >=4.1", "oldest-supported-numpy"]
 build-backend = "setuptools.build_meta"
 
 

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ mmcore_extension = Extension(
     )],
     swig_opts=[
         "-c++",
-        "-py3",
+        "-python",
         "-builtin",
         "-I./mmCoreAndDevices/MMDevice",
         "-I./mmCoreAndDevices/MMCore",


### PR DESCRIPTION
Recent versions of SWIG warn when -py3 is given.