### PR TITLE
support numpy2.0, require `numpy>=1.23.5`, add CI test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,12 +27,13 @@ jobs:
         run: pipx run check-manifest
 
   test:
-    name: Test on ${{ matrix.os }}
+    name: Test ${{ matrix.os }} py${{ matrix.python-version }} np${{ matrix.numpy }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.10', '3.12']
         numpy: ['~=1.23', '~=1.24', '~=1.26', '>=2.0.0b1']
 
     steps:
@@ -47,8 +48,9 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install .[test]
-          pip install numpy${{ matrix.numpy }}
+          python -m pip install --upgrade pip
+          python -m pip install .[test]
+          python -m pip install numpy${{ matrix.numpy }}
 
       - name: Run tests
         run: pytest -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,33 @@ jobs:
       - name: Check manifest
         run: pipx run check-manifest
 
+  test:
+    name: Test on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ['3.8', '3.9', '3.10', '3.11']
+        numpy: ['~=1.23', '~=1.24', '~=1.26', '>=2.0.0b1']
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          pip install .[test]
+          pip install numpy${{ matrix.numpy }}
+
+      - name: Run tests
+        run: pytest -v
+
   build_wheels:
     name: Build wheels on ${{ matrix.os }} ${{ matrix.macos_arch }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.8", "3.10", "3.12"]
-        numpy: ["==1.23.5", "<2.0", ">=2.0.0b1"]
+        numpy: ["==1.23.5", "~=1.26", ">=2.0.0b1"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.8", "3.10", "3.12"]
-        numpy: ["==1.23.5", "~=1.26", ">=2.0.0b1"]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        include:
+          - python-version: "3.8"
+            os: ubuntu-latest
+            numpy: "==1.23.5"
+          - python-version: "3.10"
+            os: ubuntu-latest
+            numpy: "~=1.26"
+          - python-version: "3.9"
+            os: windows-latest
+            numpy: ">=2.0.0b1"
+          - python-version: "3.12"
+            os: ubuntu-latest
+            numpy: ">=2.0.0b1"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.8', '3.10', '3.12']
-        numpy: ['~=1.23', '~=1.24', '~=1.26', '>=2.0.0b1']
+        python-version: ["3.8", "3.10", "3.12"]
+        numpy: ["==1.23.5", "<2.0", ">=2.0.0b1"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ['3.8', '3.10', '3.12']
         numpy: ['~=1.23', '~=1.24', '~=1.26', '>=2.0.0b1']
 
@@ -56,6 +56,7 @@ jobs:
         run: pytest -v
 
   build_wheels:
+    if: github.event_name != 'pull_request'
     name: Build wheels on ${{ matrix.os }} ${{ matrix.macos_arch }}
     runs-on: ${{ matrix.os }}
     strategy:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 # https://peps.python.org/pep-0517/
 [build-system]
-requires = ["setuptools >=61.0.0", "swig >=4.1", "oldest-supported-numpy"]
+# https://numpy.org/devdocs/dev/depending_on_numpy.html#adding-a-dependency-on-numpy
+requires = ["setuptools >=61.0.0", "swig >=4.1", "numpy>=2.0.0b1"]
 build-backend = "setuptools.build_meta"
-
 
 # https://peps.python.org/pep-0621/
 [project]
@@ -26,7 +26,10 @@ classifiers = [
     "Topic :: System :: Hardware :: Hardware Drivers",
     "Typing :: Typed",
 ]
-dependencies = ["numpy >=1.12.0"]
+dependencies = ["numpy>=1.23.5"]
+
+[project.optional-dependencies]
+test = ["pytest"]
 
 [project.urls]
 homepage = "https://micro-manager.org"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,18 @@
 # https://peps.python.org/pep-0517/
 [build-system]
-# https://numpy.org/devdocs/dev/depending_on_numpy.html#adding-a-dependency-on-numpy
-requires = ["setuptools >=61.0.0", "swig >=4.1", "numpy>=2.0.0b1"]
+requires = [
+    "setuptools >=61.0.0",
+    "swig >=4.1",
+    # https://github.com/scipy/oldest-supported-numpy/blob/main/setup.cfg
+    "numpy==1.19.3; python_version=='3.8' and platform_machine=='aarch64' and platform_python_implementation != 'PyPy'",
+    "numpy==1.21.0; python_version=='3.8' and platform_machine=='arm64' and platform_system=='Darwin' and platform_python_implementation!='PyPy'",
+    "numpy==1.17.5; python_version=='3.8' and platform_machine=='s390x' and platform_python_implementation != 'PyPy'",
+    "numpy==1.17.3; python_version=='3.8' and platform_machine=='arm64' and platform_system=='Windows' and platform_python_implementation != 'PyPy'",
+    "numpy==1.17.3; python_version=='3.8' and platform_machine not in 'arm64|aarch64|s390x|loongarch64' and platform_python_implementation != 'PyPy'",
+    "numpy==1.22.2; python_version=='3.8' and platform_machine!='loongarch64' and platform_python_implementation=='PyPy'",
+    # https://numpy.org/devdocs/dev/depending_on_numpy.html#adding-a-dependency-on-numpy
+    "numpy>=2.0.0b1; python_version>='3.9'",
+]
 build-backend = "setuptools.build_meta"
 
 # https://peps.python.org/pep-0621/

--- a/src/pymmcore/pymmcore_swig.i
+++ b/src/pymmcore/pymmcore_swig.i
@@ -48,7 +48,7 @@ import_array();
 %}
 
 %{
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#define NPY_NO_DEPRECATED_API NPY_1_23_API_VERSION
 #include "numpy/arrayobject.h"
 #include "string.h"
 %}


### PR DESCRIPTION
closes #113 

note that  https://github.com/scipy/oldest-supported-numpy is now deprecated

numpy has better docs and general support for [depending on numpy at build time](https://numpy.org/devdocs/dev/depending_on_numpy.html#adding-a-dependency-on-numpy) ... and this follows the advice there, namely:
- builds with `"numpy>=2.0.0b1; python_version>='3.9'",`
- `dependencies = ["numpy>=1.23.5"]`
- for python 3.8, we use the current pinnings

