### PR TITLE
Add experimental support for cross-language polymorphism on CMMCore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ src/pymmcore/pymmcore_swig.py
 pymmcore.egg-info
 .mypy_cache/
 
+.vscode

--- a/setup.py
+++ b/setup.py
@@ -23,15 +23,12 @@ import os
 import os.path
 import platform
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import numpy
 import setuptools.command.build_ext
 import setuptools.command.build_py
 from setuptools import Extension, setup
 
-if TYPE_CHECKING:
-    from typing import ContextManager, Iterable
 
 PKG_NAME = "pymmcore"
 SWIG_MOD_NAME = "pymmcore_swig"
@@ -104,29 +101,8 @@ swig_opts = [
 ]
 
 
-mmcore_extension = Extension(
-    f"{PKG_NAME}._{SWIG_MOD_NAME}",
-    sources=mmcore_sources
-    + [
-        os.path.join(
-            "src",
-            PKG_NAME,
-            f"{SWIG_MOD_NAME}.i",
-        )
-    ],
-    swig_opts=swig_opts,
-    include_dirs=[
-        numpy.get_include(),
-        "./mmCoreAndDevices/MMDevice",
-        "./mmCoreAndDevices/MMCore",
-    ],
-    libraries=mmcore_libraries,
-    define_macros=define_macros,
-)
-
-
 @contextmanager
-def add_virtual(method_names: Iterable[str]):
+def add_virtual(method_names):
     """Context in which the specified methods are declared virtual in MMCore.h."""
     MMCoreh = MMCorePath / "MMCore.h"
     original_text = MMCoreh.read_text()
@@ -138,24 +114,52 @@ def add_virtual(method_names: Iterable[str]):
             modified = True
         new_lines.append(line)
     if modified:
+        MMCoreh.with_suffix(".h.bak").write_text(original_text)
         MMCoreh.write_text("\n".join(new_lines))
     try:
         yield
     finally:
         if modified:
             MMCoreh.write_text(original_text)
+            MMCoreh.with_suffix(".h.bak").unlink()
 
 
-# Check if POLYMORPHIC_CMMCORE is set in the environment variables
-# this enables the director feature on the MMCore class
-POLYMORPHIC = os.getenv("POLYMORPHIC_CMMCORE", "").lower() in ("true", "1", "yes")
+# "POLYMORPHIC_MMCORE" is a compile-time option that enables the director
+# feature of SWIG. This feature allows python subclasses of CMMCore to re-implement
+# methods, and have the C++ side call the python implementation rather than the
+# original C++ implementation.
+# The list of methods to be overridden is may be specified in the
+# environment variable "VIRTUAL_MMCORE_METHODS", which is a comma-separated list
+# of method names. If not set, a default list of methods is used, but only if
+# POLYMORPHIC_MMCORE is set to 1.
+POLYMORPHIC = os.getenv("POLYMORPHIC_MMCORE", "").lower() in ("true", "1", "yes")
+if env_methods := os.getenv("VIRTUAL_MMCORE_METHODS"):
+    virtual_method_names = env_methods.split(",")
+    POLYMORPHIC = True
+else:
+    # could put a default list of methods to be used here when POLYMORPHIC_MMCORE=1
+    # but VIRTUAL_MMCORE_METHODS is not specified
+    virtual_method_names = []
+
 if POLYMORPHIC:
-    swig_opts.append("-DPOLYMORPHIC_CMMCORE")
-    virtual_methods = ["setFocusDevice"]
-    modified_headers: ContextManager = add_virtual(virtual_methods)
+    swig_opts.append("-DPOLYMORPHIC_MMCORE")
+    modified_headers = add_virtual(virtual_method_names)
 else:
     modified_headers = nullcontext()
 
+
+mmcore_extension = Extension(
+    f"{PKG_NAME}._{SWIG_MOD_NAME}",
+    sources=mmcore_sources + [os.path.join("src", PKG_NAME, f"{SWIG_MOD_NAME}.i")],
+    swig_opts=swig_opts,
+    include_dirs=[
+        numpy.get_include(),
+        "./mmCoreAndDevices/MMDevice",
+        "./mmCoreAndDevices/MMCore",
+    ],
+    libraries=mmcore_libraries,
+    define_macros=define_macros,
+)
 
 with modified_headers:
     setup(

--- a/src/pymmcore/__init__.pyi
+++ b/src/pymmcore/__init__.pyi
@@ -13,6 +13,7 @@ from typing_extensions import deprecated
 import numpy as np
 import numpy.typing as npt
 
+POLYMORPHIC_MMCORE: Final[Literal[0, 1]]
 MaxStrLength: int
 
 # ActionType

--- a/src/pymmcore/__init__.pyi
+++ b/src/pymmcore/__init__.pyi
@@ -13,7 +13,7 @@ from typing_extensions import deprecated
 import numpy as np
 import numpy.typing as npt
 
-POLYMORPHIC_MMCORE: Final[Literal[0, 1]]
+POLYMORPHIC_MODE: Final[Literal[0, 1]]
 MaxStrLength: int
 
 # ActionType

--- a/src/pymmcore/pymmcore_swig.i
+++ b/src/pymmcore/pymmcore_swig.i
@@ -30,10 +30,13 @@
 %module (package="pymmcore", directors="1", threads="1") pymmcore_swig
 
 %feature("director") MMEventCallback;
-#ifdef POLYMORPHIC_CMMCORE
-    %feature("director") CMMCore;
-#endif
 %feature("autodoc", "3");
+#ifdef POLYMORPHIC_MMCORE
+    %feature("director") CMMCore;
+    %constant int POLYMORPHIC_MMCORE = 1;
+#else
+    %constant int POLYMORPHIC_MMCORE = 0;
+#endif
 
 %include exception.i
 %include std_string.i

--- a/src/pymmcore/pymmcore_swig.i
+++ b/src/pymmcore/pymmcore_swig.i
@@ -30,6 +30,9 @@
 %module (package="pymmcore", directors="1", threads="1") pymmcore_swig
 
 %feature("director") MMEventCallback;
+#ifdef POLYMORPHIC_MMCORE
+    %feature("director") MMCore;
+#endif
 %feature("autodoc", "3");
 
 %include exception.i

--- a/src/pymmcore/pymmcore_swig.i
+++ b/src/pymmcore/pymmcore_swig.i
@@ -33,9 +33,9 @@
 %feature("autodoc", "3");
 #ifdef POLYMORPHIC_MMCORE
     %feature("director") CMMCore;
-    %constant int POLYMORPHIC_MMCORE = 1;
+    %constant int POLYMORPHIC_MODE = 1;
 #else
-    %constant int POLYMORPHIC_MMCORE = 0;
+    %constant int POLYMORPHIC_MODE = 0;
 #endif
 
 %include exception.i

--- a/src/pymmcore/pymmcore_swig.i
+++ b/src/pymmcore/pymmcore_swig.i
@@ -30,8 +30,8 @@
 %module (package="pymmcore", directors="1", threads="1") pymmcore_swig
 
 %feature("director") MMEventCallback;
-#ifdef POLYMORPHIC_MMCORE
-    %feature("director") MMCore;
+#ifdef POLYMORPHIC_CMMCORE
+    %feature("director") CMMCore;
 #endif
 %feature("autodoc", "3");
 
@@ -51,7 +51,7 @@ import_array();
 %}
 
 %{
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#define NPY_NO_DEPRECATED_API NPY_1_23_API_VERSION
 #include "numpy/arrayobject.h"
 #include "string.h"
 %}

--- a/tests/test_mmcore.py
+++ b/tests/test_mmcore.py
@@ -1,3 +1,4 @@
+from unittest.mock import Mock
 import pymmcore
 
 
@@ -6,7 +7,7 @@ def test_core():
     pymmcore_version = pymmcore.__version__.split(".")
 
     mmc = pymmcore.CMMCore()
-    
+
     # something like 'MMCore version 10.4.0'
     version_info = mmc.getVersionInfo()
     assert pymmcore_version[:3] == version_info.split()[-1].split(".")
@@ -15,3 +16,16 @@ def test_core():
     api_version_info = mmc.getAPIVersionInfo()
     dev_interface_version = api_version_info.split(",")[0].split()[-1]
     assert pymmcore_version[3] == dev_interface_version
+
+
+def test_polymorphism():
+    mock = Mock()
+
+    class MySubCore(pymmcore.CMMCore):
+        def setFocusDevice(self, focusLabel: str) -> None:
+            mock(focusLabel)
+
+    core = MySubCore()
+    lbl = ""
+    core.setProperty(pymmcore.g_Keyword_CoreDevice, pymmcore.g_Keyword_CoreFocus, lbl)
+    mock.assert_called_once_with(lbl)

--- a/tests/test_mmcore.py
+++ b/tests/test_mmcore.py
@@ -1,4 +1,6 @@
 from unittest.mock import Mock
+
+import pytest
 import pymmcore
 
 
@@ -18,6 +20,7 @@ def test_core():
     assert pymmcore_version[3] == dev_interface_version
 
 
+@pytest.mark.skipif(pymmcore.POLYMORPHIC_MODE == 0, reason="POLYMORPHIC_MODE is 0")
 def test_polymorphism():
     mock = Mock()
 
@@ -29,5 +32,3 @@ def test_polymorphism():
     lbl = ""
     core.setProperty(pymmcore.g_Keyword_CoreDevice, pymmcore.g_Keyword_CoreFocus, lbl)
     mock.assert_called_once_with(lbl)
-
-    assert pymmcore.POLYMORPHIC_MMCORE == 1

--- a/tests/test_mmcore.py
+++ b/tests/test_mmcore.py
@@ -29,3 +29,5 @@ def test_polymorphism():
     lbl = ""
     core.setProperty(pymmcore.g_Keyword_CoreDevice, pymmcore.g_Keyword_CoreFocus, lbl)
     mock.assert_called_once_with(lbl)
+
+    assert pymmcore.POLYMORPHIC_MMCORE == 1


### PR DESCRIPTION
For a couple things in pymmcore-plus, it would be nice if the methods on my re-implemented subclass were called by the C-level core object (i.e. "cross-language polymorphism").    For example

```python
import pymmcore

class MySubCore(pymmcore.CMMCore):
    def setFocusDevice(self, focusLabel: str) -> None:
        print("Hello! from C++")

core = MySubCore()
core.setProperty("Core", "Focus", "")
```

that should print ("Hello! from C++")

---- 
Swig allows this feature with directors:

> The director feature enables the ability for a target language class to derive from a wrapped C++ class. The target language can override virtual methods of a wrapped C++ class, thereby supporting cross-language polymorphism. Code can 'call up' from C++ into the target language by simply calling a virtual method overridden in a derived class in the target language. 

but it's currently disabled for CMMCore... which makes perfect sense because none of the methods defined in MMCore.h are virtual methods.

This PR enables experimental support for polymorphic virtual methods without making any modifications to mmCoreAndDevices by:
- looking for `VIRTUAL_MMCORE_METHODS` env var at build time, which should be a comma-separrated list of method names, like `VIRTUAL_MMCORE_METHODS=setFocusDevice,setCameraDevice`
- if found, patches MMCore.h in a context manager during compile time to make those methods virtual
- enables the the `%feature("director") CMMCore;` flag inside the swig file.

There's a test that shows that it works (which isn't being run on CI at the moment, but works locally).

@marktsuchida, I wonder whether you'd consider this?  Ultimately, a better question is whether this could be the default, but since I don't know too much about the implications of making methods virtual, I didn't want to leap to modifying MMCore.h itself, but it might make for a reasonable default (for pymmcore) to add virtual to a number of MMCore methods that are called internally by Core