### PR TITLE
CI: build with VS2019 toolset for Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,10 @@ jobs:
         with:
           submodules: "recursive"
 
+      - uses: ilammy/msvc-dev-cmd@v1
+        with:
+          toolset: "14.2"
+
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.16
         env:


### PR DESCRIPTION
This (compared to using the latest VS2022, as we currently do) increases the chance that pymmcore will work with whatever version of the C++ runtime that gets loaded (possibly by other modules imported before us). It may also help with installed by pip into a Conda environment, though that is not a recommended use case.

~Hopefully~ closes #119.