### PR TITLE
build: support python 3.13, drop python 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,21 +32,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.10", "3.12", "3.13"]
+        python-version: ["3.9", "3.11", "3.13"]
         os: [ubuntu-latest, windows-latest, macos-latest]
         include:
-          - python-version: "3.8"
+          - python-version: "3.9"
             os: ubuntu-latest
-            numpy: "==1.23.5"
+            numpy: "~=1.25"
           - python-version: "3.10"
             os: ubuntu-latest
             numpy: "~=1.26"
-          - python-version: "3.9"
-            os: windows-latest
-            numpy: ">=2.0.0b1"
           - python-version: "3.12"
             os: ubuntu-latest
-            numpy: ">=2.0.0b1"
+            numpy: ">=2.0.0"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.10", "3.12"]
+        python-version: ["3.8", "3.10", "3.12", "3.13"]
         os: [ubuntu-latest, windows-latest, macos-latest]
         include:
           - python-version: "3.8"
@@ -57,6 +57,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
 
       - name: Install dependencies
         run: |

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Because pymmcore is distributed separately from Micro-Manager, it needs to be
 
 ## Installing
 
-Suports Python 3.8 or later and Windows, macOS, and Linux (all 64-bit).
+Suports Python 3.9 or later and Windows, macOS, and Linux (all 64-bit).
 
 ```
 pip install pymmcore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ version = { attr = "pymmcore._version.__version__" }
 # Note: use of PTHREAD_MUTEX_RECURSIVE_NP in DeviceThreads.h
 # is specific to glibc and not available in musl-libc
 skip = ["*-manylinux_i686", "*-musllinux*", "*-win32", "pp*"]
-build = ["cp38-*", "cp39-*", "cp310-*", "cp311-*", "cp312-*"]
+build = ["cp38-*", "cp39-*", "cp310-*", "cp311-*", "cp312-*", "cp313-*"]
 test-requires = "pytest"
 test-command = 'pytest "{project}/tests" -v'
 test-skip = "*-macosx_arm64"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,18 +1,6 @@
 # https://peps.python.org/pep-0517/
 [build-system]
-requires = [
-    "setuptools ==72.1.0",
-    "swig >=4.1",
-    # https://github.com/scipy/oldest-supported-numpy/blob/main/setup.cfg
-    "numpy==1.19.3; python_version=='3.8' and platform_machine=='aarch64' and platform_python_implementation != 'PyPy'",
-    "numpy==1.21.0; python_version=='3.8' and platform_machine=='arm64' and platform_system=='Darwin' and platform_python_implementation!='PyPy'",
-    "numpy==1.17.5; python_version=='3.8' and platform_machine=='s390x' and platform_python_implementation != 'PyPy'",
-    "numpy==1.17.3; python_version=='3.8' and platform_machine=='arm64' and platform_system=='Windows' and platform_python_implementation != 'PyPy'",
-    "numpy==1.17.3; python_version=='3.8' and platform_machine not in 'arm64|aarch64|s390x|loongarch64' and platform_python_implementation != 'PyPy'",
-    "numpy==1.22.2; python_version=='3.8' and platform_machine!='loongarch64' and platform_python_implementation=='PyPy'",
-    # https://numpy.org/devdocs/dev/depending_on_numpy.html#adding-a-dependency-on-numpy
-    "numpy>=2.0.0b1; python_version>='3.9'",
-]
+requires = ["setuptools ==72.1.0", "swig >=4.1", "numpy>=2.0.0"]
 build-backend = "setuptools.build_meta"
 
 # https://peps.python.org/pep-0621/
@@ -21,7 +9,7 @@ name = "pymmcore"
 description = "Python bindings for MMCore, Micro-Manager's device control layer"
 dynamic = ["version"]
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = { text = "LGPL-2.1-only" }
 authors = [{ name = "Micro-Manager Team" }]
 classifiers = [
@@ -37,7 +25,7 @@ classifiers = [
     "Topic :: System :: Hardware :: Hardware Drivers",
     "Typing :: Typed",
 ]
-dependencies = ["numpy>=1.23.5"]
+dependencies = ["numpy>=1.25"]
 
 [project.optional-dependencies]
 test = ["pytest"]
@@ -61,7 +49,7 @@ version = { attr = "pymmcore._version.__version__" }
 # Note: use of PTHREAD_MUTEX_RECURSIVE_NP in DeviceThreads.h
 # is specific to glibc and not available in musl-libc
 skip = ["*-manylinux_i686", "*-musllinux*", "*-win32", "pp*"]
-build = ["cp38-*", "cp39-*", "cp310-*", "cp311-*", "cp312-*", "cp313-*"]
+build = ["cp39-*", "cp310-*", "cp311-*", "cp312-*", "cp313-*"]
 test-requires = "pytest"
 test-command = 'pytest "{project}/tests" -v'
 test-skip = "*-macosx_arm64"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # https://peps.python.org/pep-0517/
 [build-system]
 requires = [
-    "setuptools >=61.0.0",
+    "setuptools ==72.1.0",
     "swig >=4.1",
     # https://github.com/scipy/oldest-supported-numpy/blob/main/setup.cfg
     "numpy==1.19.3; python_version=='3.8' and platform_machine=='aarch64' and platform_python_implementation != 'PyPy'",


### PR DESCRIPTION
curious to see whether it fails.  

for some reason, I'm currently unable to build pymmcore with any version of python locally on my mac:

```python
* Building wheel...
No `packages` or `py_modules` configuration, performing automatic discovery.
`src-layout` detected -- analysing ./src
discovered packages -- ['pymmcore']
discovered py_modules -- []
running bdist_wheel
running build
running build_py
running build_ext
running build_clib
building 'MMDevice' library
creating build/temp.macosx-11.0-arm64-cpython-312/mmCoreAndDevices/MMDevice
clang++ -fno-strict-overflow -DNDEBUG -O2 -Wall -fPIC -O2 -isystem /Users/talley/miniforge3/envs/py312/include -arch arm64 -fPIC -O2 -isystem /Users/talley/miniforge3/envs/py312/include -arch arm64 -DMMDEVICE_CLIENT_BUILD -ImmCoreAndDevices/MMDevice -c mmCoreAndDevices/MMDevice/Debayer.cpp -o build/temp.macosx-11.0-arm64-cpython-312/mmCoreAndDevices/MMDevice/Debayer.o
In file included from mmCoreAndDevices/MMDevice/Debayer.cpp:26:
In file included from mmCoreAndDevices/MMDevice/Debayer.h:27:
In file included from mmCoreAndDevices/MMDevice/ImgBuffer.h:26:
mmCoreAndDevices/MMDevice/ImageMetadata.h:329:58: error: ISO C++17 does not allow dynamic exception specifications [-Wdynamic-exception-spec]
  329 |    MetadataSingleTag GetSingleTag(const char* key) const throw (MetadataKeyError)
      |                                                          ^~~~~~~~~~~~~~~~~~~~~~~~
mmCoreAndDevices/MMDevice/ImageMetadata.h:329:58: note: use 'noexcept(false)' instead
  329 |    MetadataSingleTag GetSingleTag(const char* key) const throw (MetadataKeyError)
      |                                                          ^~~~~~~~~~~~~~~~~~~~~~~~
      |                                                          noexcept(false)
mmCoreAndDevices/MMDevice/ImageMetadata.h:336:56: error: ISO C++17 does not allow dynamic exception specifications [-Wdynamic-exception-spec]
  336 |    MetadataArrayTag GetArrayTag(const char* key) const throw (MetadataKeyError)
      |                                                        ^~~~~~~~~~~~~~~~~~~~~~~~
mmCoreAndDevices/MMDevice/ImageMetadata.h:336:56: note: use 'noexcept(false)' instead
  336 |    MetadataArrayTag GetArrayTag(const char* key) const throw (MetadataKeyError)
      |                                                        ^~~~~~~~~~~~~~~~~~~~~~~~
      |                                                        noexcept(false)
2 errors generated.
error: command '/opt/homebrew/opt/llvm/bin/clang++' failed with exit code 1

ERROR Backend subprocess exited when trying to invoke build_wheel
```


probably something on my end