### PR TITLE
ci: bump version of cibuildwheel

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci(dependabot):"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
         run: pytest -v
 
   build_wheels:
-    if: github.event_name != 'pull_request'
+    # if: github.event_name != 'pull_request'
     name: Build wheels on ${{ matrix.os }} ${{ matrix.macos_arch }}
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,11 +72,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, windows-2022]
+        os: [ubuntu-latest, windows-latest]
         include:
-          - os: macos-12
+          - os: macos-13
             macos_arch: "x86_64"
-          - os: macos-12
+          - os: macos-latest
             macos_arch: "arm64"
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,8 +89,9 @@ jobs:
           toolset: "14.2"
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.19
+        uses: pypa/cibuildwheel@v2.22
         env:
+          CIBW_VERBOSE: 1
           CIBW_ARCHS_MACOS: "${{ matrix.macos_arch }}"
           # Python on Linux is usually configured to add debug information,
           # which increases binary size by ~11-fold. Remove for the builds we

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
         run: pytest -v
 
   build_wheels:
-    # if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request'
     name: Build wheels on ${{ matrix.os }} ${{ matrix.macos_arch }}
     runs-on: ${{ matrix.os }}
     strategy:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 # https://peps.python.org/pep-0517/
 [build-system]
-requires = ["setuptools ==72.1.0", "swig >=4.1", "numpy>=2.0.0"]
+requires = ["setuptools ==72.1.0", "swig ==4.2.1", "numpy>=2.0.0"]
 build-backend = "setuptools.build_meta"
 
 # https://peps.python.org/pep-0621/
@@ -57,6 +57,8 @@ test-skip = "*-macosx_arm64"
 [tool.cibuildwheel.macos]
 # https://cibuildwheel.readthedocs.io/en/stable/faq/#apple-silicon
 archs = ["x86_64", "arm64"]
+# Needed for C++17 support on macOS
+environment = { MACOSX_DEPLOYMENT_TARGET = "10.14" }
 
 [tool.check-manifest]
 ignore = [".editorconfig", "Dockerfile", "maintainer-notes.md", ".gitmodules"]


### PR DESCRIPTION
Im trying figure out why python 3.13 wheels didn't get added to PyPI when the action ran on Oct 7: https://github.com/micro-manager/pymmcore/actions/runs/11220032864/job/31187312757#step:4:300

as far as I can tell, everything in the action and pyproject.toml look good.  So my best guess/hope is that python 3.13, which was released that same day, simply wasn't available for download when cibuildwheel looked for it.  I think that running it again might fix it, but this PR just adds verbosity to cibuildwheel, updates its version, and adds dependabot updates to our github actions

closes #125 