### PR TITLE
Updates for v2 buffer

### DIFF
--- a/src/pymmcore/pymmcore_swig.i
+++ b/src/pymmcore/pymmcore_swig.i
@@ -62,7 +62,6 @@ import_array();
         return $result;
     }
 
-    // TODO: need to all null check here?
     int width, height, bytesPerPixel, numComponents;
     (arg1)->getImageProperties(result, width, height, bytesPerPixel, numComponents);
     int pixelCount = width * height;

--- a/src/pymmcore/pymmcore_swig.i
+++ b/src/pymmcore/pymmcore_swig.i
@@ -324,7 +324,7 @@ import_array();
 #include "ImageMetadata.h"
 #include "MMEventCallback.h"
 #include "MMCore.h"
-#include "NewBufferDataPointer.h"
+#include "NewDataBufferPointer.h"
 %}
 
 // Exception handling. Tranditionally, MMCore uses exception specifications
@@ -449,4 +449,4 @@ namespace std {
 %include "MMCore.h"
 %include "ImageMetadata.h"
 %include "MMEventCallback.h"
-%include "NewBufferDataPointer.h"
+%include "NewDataBufferPointer.h"

--- a/src/pymmcore/pymmcore_swig.i
+++ b/src/pymmcore/pymmcore_swig.i
@@ -119,7 +119,23 @@ import_array();
     }
 
     int width, height, bytesPerPixel, numComponents;
-    (arg1)->getImageProperties(width, height, bytesPerPixel, numComponents);
+    bool propertiesOK = (arg1)->getImageProperties(width, height, bytesPerPixel, numComponents);
+    
+    // If getImageProperties fails, its not image data. Assume 1 byte per pixel
+    // If more data types are supported in the future, could add other
+    // checks here to return other data types.
+    if (!propertiesOK) {
+        bytesPerPixel = 1;
+        numComponents = 1;
+        int pixelCount = numBytes;
+        npy_intp dims[1] = {pixelCount};
+        
+        PyObject * numpyArray = PyArray_SimpleNew(1, dims, NPY_UINT8);
+        memcpy(PyArray_DATA((PyArrayObject *) numpyArray), result, pixelCount);
+        $result = numpyArray;
+        return $result;
+    }
+    
     int pixelCount = width * height;
     npy_intp dims[2] = {height, width};
 

--- a/src/pymmcore/pymmcore_swig.i
+++ b/src/pymmcore/pymmcore_swig.i
@@ -324,7 +324,7 @@ import_array();
 #include "ImageMetadata.h"
 #include "MMEventCallback.h"
 #include "MMCore.h"
-#include "BufferDataPointer.h"
+#include "NewBufferDataPointer.h"
 %}
 
 // Exception handling. Tranditionally, MMCore uses exception specifications
@@ -449,4 +449,4 @@ namespace std {
 %include "MMCore.h"
 %include "ImageMetadata.h"
 %include "MMEventCallback.h"
-%include "BufferDataPointer.h"
+%include "NewBufferDataPointer.h"


### PR DESCRIPTION
This PR provides updates to the SWIG wrapper to enable use of the v2 buffer, once merged in https://github.com/micro-manager/mmCoreAndDevices/pull/570. These changes should provide the same performance benefits described there.

I tried to keep these changes minimal. In particular one difference from my changes to java SWIG wrapper is that I did not make higher level classes analogous to [TaggedImagePointer](https://github.com/henrypinkard/mmCoreAndDevices/blob/data_buffer_new_new/MMCoreJ_wrap/src/main/java/mmcorej/TaggedImagePointer.java) and [LazyJSONObject](https://github.com/henrypinkard/mmCoreAndDevices/blob/data_buffer_new_new/MMCoreJ_wrap/src/main/java/mmcorej/LazyJSONObject.java). Ad advantage to doing something like this is that unlike Java, the pymmcore has the additional opportunity for creating direct, zero-copy views into the v2 buffer. For example, here's how to use the SWIG wrapped objects for pointer-based image handling now:

```python
core.enableV2Buffer(True)
core.snapImage()

# This does returns just a SWIG-wrapped object, but performs no copy
buffer_data_pointer = core.getImagePointer()
# Analogous versions for sequences: popNextImagePointer(), etc

# get the image pixels -- this copies data
pixels = buffer_data_pointer.getData()

# get metadata
md = pymmcore.Metadata()
buffer_data_pointer.getMetadata(md)

# allow the memory holding the pointer to be recycled
buffer_data_pointer.release()
```

An additional wrapping object should be able to avoid the copy in `pixels = buffer_data_pointer.getData()`, and instead return some numpy-array like object that is read-only and has a release method (or handles this automatically when garbage collected -- though that is probably less reliable).

I'm not sure what the most desirable way to handle this is, so I'll defer to you @marktsuchida @tlambert03 

The functions needed to implement it are already enabled:

```python
address = buffer_data_pointer.getDataPointer() # the memory address of the image  (or other) data
size = buffer_data_pointer.getSizeBytes() # the number of bytes of image (or other) data
```

Tests for this new API can be found [here](https://github.com/micro-manager/mmpycorex/blob/main/test/buffer_tests.ipynb): 

I'm not sure how the pymmcore version numbering works so I'll leave that to you.