### PR TITLE
Upgrade MMCore to 12.5.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -18,7 +18,7 @@
 project(
     'pymmcore',
     'cpp',
-    version: '12.4.0.75.0.dev0',
+    version: '12.5.0.75.0.dev0',
     meson_version: '>=1.8.0',
     default_options: [
         'cpp_std=c++17',

--- a/src/pymmcore/__init__.pyi
+++ b/src/pymmcore/__init__.pyi
@@ -522,6 +522,8 @@ class CMMCore:
         self, label: DeviceLabel | str
     ) -> Tuple[PropertyName, ...]:
         """Returns all property names supported by the device."""
+    def getDeviceTimeoutMs(self, label: DeviceLabel | str) -> int:
+        """Returns the per-device timeout in milliseconds, or the default if not set."""
     def getDeviceType(self, label: DeviceLabel | str) -> DeviceType:
         """Returns device type."""
     @overload
@@ -620,6 +622,16 @@ class CMMCore:
     def getMagnificationFactor(self) -> float:
         """Returns the product of all Magnifiers in the system or 1.0 when none is found.
         This is used internally by GetPixelSizeUm"""
+    @staticmethod
+    def getMMCoreVersionMajor() -> int: ...
+    @staticmethod
+    def getMMCoreVersionMinor() -> int: ...
+    @staticmethod
+    def getMMCoreVersionPatch() -> int: ...
+    @staticmethod
+    def getMMDeviceDeviceInterfaceVersion() -> int: ...
+    @staticmethod
+    def getMMDeviceModuleInterfaceVersion() -> int: ...
     # def getMultiROI(self) -> List[Any]: ...  # this overload doesn't seem to be present
     def getMultiROI(
         self,
@@ -875,6 +887,8 @@ class CMMCore:
     @overload
     def getYPosition(self, xyStageLabel: DeviceLabel | str) -> float:
         """Obtains the current position of the Y axis of the XY stage in microns."""
+    def hasDeviceTimeout(self, label: DeviceLabel | str) -> bool:
+        """Returns True if a per-device timeout has been set for the given device."""
     def hasProperty(
         self, label: DeviceLabel | str, propName: PropertyName | str
     ) -> bool:
@@ -1119,6 +1133,8 @@ class CMMCore:
         """Set the device adapter search paths."""
     def setDeviceDelayMs(self, label: DeviceLabel | str, delayMs: float) -> None:
         """Overrides the built-in value for the action delay."""
+    def setDeviceTimeoutMs(self, label: DeviceLabel | str, timeoutMs: int) -> None:
+        """Sets a per-device timeout in milliseconds."""
     @overload
     def setExposure(self, exp: float) -> None:
         """Sets the exposure setting of the current camera in milliseconds."""
@@ -1381,14 +1397,14 @@ class CMMCore:
     ) -> int: ...
     @overload
     def startSequenceAcquisition(
-        self, numImages: int, intervalMs: float, stopOnOverflow: bool
+        self, numImages: int, unused: float, stopOnOverflow: bool
     ) -> None: ...
     @overload
     def startSequenceAcquisition(
         self,
         cameraLabel: DeviceLabel | str,
         numImages: int,
-        intervalMs: float,
+        unused: float,
         stopOnOverflow: bool,
     ) -> None: ...
     def startSLMSequence(self, slmLabel: DeviceLabel | str) -> None:
@@ -1443,6 +1459,8 @@ class CMMCore:
         """Unloads the device from the core and adjusts all configuration data."""
     def unloadLibrary(self, moduleName: AdapterName | str) -> None:
         """Forcefully unload a library."""
+    def unsetDeviceTimeout(self, label: DeviceLabel | str) -> None:
+        """Removes any per-device timeout, restoring the default."""
     def updateCoreProperties(self) -> None:
         """Updates CoreProperties (currently all Core properties are devices types) with
         the loaded hardware."""

--- a/subprojects/mmcore.wrap
+++ b/subprojects/mmcore.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/micro-manager/mmcore.git
-revision = 29e7de3344988e4b5886c4d7368f72fd61366e42
+revision = 8399a00b7210fd0775f3fe51392828a69c9aa57b
 depth = 1
 
 [provide]

--- a/subprojects/mmdevice.wrap
+++ b/subprojects/mmdevice.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/micro-manager/mmdevice.git
-revision = 7e648e90ec170dcdc1a798d596f9b358e4cd8eb6
+revision = b31dbbcca65a9a5120232518b9b061e81092a896
 depth = 1
 
 [provide]


### PR DESCRIPTION
Main update is per-device timeout API.

This includes (post-12.5.0) some added tests and internal cleanup.

The `startSequenceAcquisition` parameter `intervalMs` has been renamed to `unused`. This should not affect the Python API because we do not have kwarg support enabled in SWIG.

MMCore version number methods were also added to type hints (were missing).